### PR TITLE
fix: dependencies for node types of any version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     ]
   },
   "dependencies": {
-    "@types/node": "*"
+    "@types/node": ">= 8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     ]
   },
   "dependencies": {
-    "@types/node": "^12.11.1"
+    "@types/node": "*"
   }
 }


### PR DESCRIPTION
NodeJS types of version 8, 10 and 12 are not compatible and alongside cause type errors. If one of dependencies in dependency tree requires specific NodeJS type version, then most likely the project will end up with two (or more) NodeJS types. Therefore if you support any NodeJS version then also require any of NodeJS type versions, using `*`, `>= 8`, or what's more appropriate.
