### PR TITLE
feat: `GetResponseTypeFromEndpointMethod` and `GetResponseDataTypeFromEndpointMethod` helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,21 @@
 
 ## Usage
 
+Get response types from endpoint methods
+
+```ts
+import { GetResponseType, GetResponseDataType } from "@octokit/types";
+import { Octokit } from "@octokit/rest";
+
+const octokit = new Octokit();
+type CreateLabelResponseType = GetResponseType<
+  typeof octokit.issues.createLabel
+>;
+type CreateLabelResponseDataType = GetResponseDataType<
+  typeof octokit.issues.createLabel
+>;
+```
+
 See https://octokit.github.io/types.ts for all exported types
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@
 Get response types from endpoint methods
 
 ```ts
-import { GetResponseType, GetResponseDataType } from "@octokit/types";
+import {
+  GetResponseTypeFromEndpointMethod,
+  GetResponseDataTypeFromEndpointMethod,
+} from "@octokit/types";
 import { Octokit } from "@octokit/rest";
 
 const octokit = new Octokit();

--- a/src/GetResponseType.ts
+++ b/src/GetResponseType.ts
@@ -1,7 +1,0 @@
-type Unwrap<T> = T extends Promise<infer U> ? U : T;
-type AnyFunction = (...args) => any;
-
-export type GetResponseType<T extends AnyFunction> = Unwrap<ReturnType<T>>;
-export type GetResponseDataType<T extends AnyFunction> = Unwrap<
-  ReturnType<T>
->["data"];

--- a/src/GetResponseType.ts
+++ b/src/GetResponseType.ts
@@ -1,0 +1,7 @@
+type Unwrap<T> = T extends Promise<infer U> ? U : T;
+type AnyFunction = (...args) => any;
+
+export type GetResponseType<T extends AnyFunction> = Unwrap<ReturnType<T>>;
+export type GetResponseDataType<T extends AnyFunction> = Unwrap<
+  ReturnType<T>
+>["data"];

--- a/src/GetResponseTypeFromEndpointMethod.ts
+++ b/src/GetResponseTypeFromEndpointMethod.ts
@@ -1,0 +1,9 @@
+type Unwrap<T> = T extends Promise<infer U> ? U : T;
+type AnyFunction = (...args) => any;
+
+export type GetResponseTypeFromEndpointMethod<T extends AnyFunction> = Unwrap<
+  ReturnType<T>
+>;
+export type GetResponseDataTypeFromEndpointMethod<
+  T extends AnyFunction
+> = Unwrap<ReturnType<T>>["data"];

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,4 +16,4 @@ export * from "./Signal";
 export * from "./StrategyInterface";
 export * from "./Url";
 export * from "./VERSION";
-export * from "./GetResponseType";
+export * from "./GetResponseTypeFromEndpointMethod";

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,3 +16,4 @@ export * from "./Signal";
 export * from "./StrategyInterface";
 export * from "./Url";
 export * from "./VERSION";
+export * from "./GetResponseType";


### PR DESCRIPTION
fixes #31