### PR TITLE
Add optional defaults type parameter to EndpointInterface & RequestInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,23 @@
 [![Build Status](https://github.com/octokit/types.ts/workflows/Test/badge.svg)](https://github.com/octokit/types.ts/actions?workflow=Test)
 [![Greenkeeper](https://badges.greenkeeper.io/octokit/types.ts.svg)](https://greenkeeper.io/)
 
+<!-- toc -->
+
+- [Usage](#usage)
+  - [Get parameter and response data types for a REST API endpoint](#get-parameter-and-response-data-types-for-a-rest-api-endpoint)
+  - [Get response types from endpoint methods](#get-response-types-from-endpoint-methods)
+- [Contributing](#contributing)
+- [License](#license)
+
+<!-- tocstop -->
+
 ## Usage
 
-Get parameter and response data types for a REST API endpoint
+See all exported types at https://octokit.github.io/types.ts
+
+## Examples
+
+### Get parameter and response data types for a REST API endpoint
 
 ```ts
 import { Endpoints } from "./src";
@@ -23,7 +37,7 @@ async function listRepos(
 }
 ```
 
-Get response types from endpoint methods
+### Get response types from endpoint methods
 
 ```ts
 import {
@@ -40,8 +54,6 @@ type CreateLabelResponseDataType = GetResponseDataTypeFromEndpointMethod<
   typeof octokit.issues.createLabel
 >;
 ```
-
-See https://octokit.github.io/types.ts for all exported types
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <!-- toc -->
 
 - [Usage](#usage)
+- [Examples](#examples)
   - [Get parameter and response data types for a REST API endpoint](#get-parameter-and-response-data-types-for-a-rest-api-endpoint)
   - [Get response types from endpoint methods](#get-response-types-from-endpoint-methods)
 - [Contributing](#contributing)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "prettier --check '{src,test,scripts}/**/*.{js,ts,json}' README.md package.json !src/generated/* !scripts/update-endpoints/generated/*",
     "lint:fix": "prettier --write '{src,test,scripts}/**/*.{js,ts,json}' README.md package.json !src/generated/* !scripts/update-endpoints/generated/*",
     "pretest": "npm run -s lint",
-    "test": "npx tsc --noEmit --declaration src/index.ts",
+    "test": "npx tsc --noEmit --declaration src/index.ts test.ts",
     "update-endpoints": "npm-run-all update-endpoints:*",
     "update-endpoints:fetch-json": "node scripts/update-endpoints/fetch-json",
     "update-endpoints:typescript": "node scripts/update-endpoints/typescript"

--- a/scripts/update-endpoints/templates/endpoints.ts.template
+++ b/scripts/update-endpoints/templates/endpoints.ts.template
@@ -41,7 +41,7 @@ type {{request.name}} = {
 {{/each}}
 
 {{#childParams}}
-export type {{paramTypeName}} = {
+type {{paramTypeName}} = {
 {{#params}}
   {{{name this}}}: {{{type this}}}
 {{/params}}

--- a/src/EndpointInterface.ts
+++ b/src/EndpointInterface.ts
@@ -9,7 +9,7 @@ export interface EndpointInterface<D extends object = object> {
   /**
    * Transforms a GitHub REST API endpoint into generic request options
    *
-   * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
+   * @param {object} endpoint Must set `url` unless it's set defaults. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
   <O extends RequestParameters = RequestParameters>(
     options: O & { method?: string } & ("url" extends keyof D

--- a/src/EndpointInterface.ts
+++ b/src/EndpointInterface.ts
@@ -1,18 +1,21 @@
 import { EndpointDefaults } from "./EndpointDefaults";
-import { EndpointOptions } from "./EndpointOptions";
 import { RequestOptions } from "./RequestOptions";
 import { RequestParameters } from "./RequestParameters";
 import { Route } from "./Route";
 
 import { Endpoints } from "./generated/Endpoints";
 
-export interface EndpointInterface {
+export interface EndpointInterface<D extends object = object> {
   /**
    * Transforms a GitHub REST API endpoint into generic request options
    *
    * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  (options: EndpointOptions): RequestOptions;
+  <O extends RequestParameters = RequestParameters>(
+    options: O & { method?: string } & ("url" extends keyof D
+        ? { url?: string }
+        : { url: string })
+  ): RequestOptions & Pick<D & O, keyof RequestOptions>;
 
   /**
    * Transforms a GitHub REST API endpoint into generic request options
@@ -20,22 +23,28 @@ export interface EndpointInterface {
    * @param {string} route Request method + URL. Example: `'GET /orgs/:org'`
    * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  <R extends Route>(
-    route: keyof Endpoints | R,
-    options?: R extends keyof Endpoints
+  <
+    R extends Route,
+    P extends RequestParameters = R extends keyof Endpoints
       ? Endpoints[R]["parameters"] & RequestParameters
       : RequestParameters
-  ): R extends keyof Endpoints ? Endpoints[R]["request"] : RequestOptions;
+  >(
+    route: keyof Endpoints | R,
+    parameters?: P
+  ): (R extends keyof Endpoints ? Endpoints[R]["request"] : RequestOptions) &
+    Pick<P, keyof RequestOptions>;
 
   /**
    * Object with current default route and parameters
    */
-  DEFAULTS: EndpointDefaults;
+  DEFAULTS: D & EndpointDefaults;
 
   /**
-   * Returns a new `endpoint` with updated route and parameters
+   * Returns a new `endpoint` interface with new defaults
    */
-  defaults: (newDefaults: RequestParameters) => EndpointInterface;
+  defaults: <O extends RequestParameters = RequestParameters>(
+    newDefaults: O
+  ) => EndpointInterface<D & O>;
 
   merge: {
     /**
@@ -46,7 +55,19 @@ export interface EndpointInterface {
      * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
      *
      */
-    (route: Route, parameters?: RequestParameters): EndpointDefaults;
+    <
+      R extends Route,
+      P extends RequestParameters = R extends keyof Endpoints
+        ? Endpoints[R]["parameters"] & RequestParameters
+        : RequestParameters
+    >(
+      route: keyof Endpoints | R,
+      parameters?: P
+    ): D &
+      (R extends keyof Endpoints
+        ? Endpoints[R]["request"] & Endpoints[R]["parameters"]
+        : EndpointDefaults) &
+      P;
 
     /**
      * Merges current endpoint defaults with passed route and parameters,
@@ -54,14 +75,16 @@ export interface EndpointInterface {
      *
      * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
      */
-    (options: RequestParameters): EndpointDefaults;
+    <P extends RequestParameters = RequestParameters>(
+      options: P
+    ): EndpointDefaults & D & P;
 
     /**
      * Returns current default options.
      *
      * @deprecated use endpoint.DEFAULTS instead
      */
-    (): EndpointDefaults;
+    (): D & EndpointDefaults;
   };
 
   /**
@@ -70,5 +93,7 @@ export interface EndpointInterface {
    *
    * @param {object} options `method`, `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  parse: (options: EndpointDefaults) => RequestOptions;
+  parse: <O extends EndpointDefaults = EndpointDefaults>(
+    options: O
+  ) => RequestOptions & Pick<O, keyof RequestOptions>;
 }

--- a/src/RequestInterface.ts
+++ b/src/RequestInterface.ts
@@ -6,13 +6,17 @@ import { Route } from "./Route";
 
 import { Endpoints } from "./generated/Endpoints";
 
-export interface RequestInterface {
+export interface RequestInterface<D extends object = object> {
   /**
    * Sends a request based on endpoint options
    *
    * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  <T = any>(options: EndpointOptions): Promise<OctokitResponse<T>>;
+  <T = any, O extends RequestParameters = RequestParameters>(
+    options: O & { method?: string } & ("url" extends keyof D
+        ? { url?: string }
+        : { url: string })
+  ): Promise<OctokitResponse<T>>;
 
   /**
    * Sends a request based on endpoint options
@@ -30,12 +34,14 @@ export interface RequestInterface {
     : Promise<OctokitResponse<any>>;
 
   /**
-   * Returns a new `endpoint` with updated route and parameters
+   * Returns a new `request` with updated route and parameters
    */
-  defaults: (newDefaults: RequestParameters) => RequestInterface;
+  defaults: <O extends RequestParameters = RequestParameters>(
+    newDefaults: O
+  ) => RequestInterface<D & O>;
 
   /**
    * Octokit endpoint API, see {@link https://github.com/octokit/endpoint.js|@octokit/endpoint}
    */
-  endpoint: EndpointInterface;
+  endpoint: EndpointInterface<D>;
 }

--- a/src/RequestParameters.ts
+++ b/src/RequestParameters.ts
@@ -42,5 +42,5 @@ export type RequestParameters = {
    * 3. Request body if `parameter` is `'data'`
    * 4. JSON in the request body in the form of `body[parameter]` unless `parameter` key is `'data'`
    */
-  [parameter: string]: any;
+  [parameter: string]: unknown;
 };

--- a/src/generated/Endpoints.ts
+++ b/src/generated/Endpoints.ts
@@ -42426,62 +42426,62 @@ type ActivityListReposWatchedByUserResponseData = Array<
   ActivityListReposWatchedByUserResponseDataItem
 >;
 
-export type AppsCreateInstallationTokenParamsPermissions = {};
-export type GistsCreateParamsFiles = {
+type AppsCreateInstallationTokenParamsPermissions = {};
+type GistsCreateParamsFiles = {
   content?: string;
 };
-export type GistsUpdateParamsFiles = {
+type GistsUpdateParamsFiles = {
   content?: string;
   filename?: string;
 };
-export type OrgsCreateHookParamsConfig = {
+type OrgsCreateHookParamsConfig = {
   url: string;
   content_type?: string;
   secret?: string;
   insecure_ssl?: string;
 };
-export type OrgsUpdateHookParamsConfig = {
+type OrgsUpdateHookParamsConfig = {
   url: string;
   content_type?: string;
   secret?: string;
   insecure_ssl?: string;
 };
-export type TeamsCreateOrUpdateIdPGroupConnectionsInOrgParamsGroups = {
+type TeamsCreateOrUpdateIdPGroupConnectionsInOrgParamsGroups = {
   group_id: string;
   group_name: string;
   group_description: string;
 };
-export type ReposUpdateBranchProtectionParamsRequiredStatusChecks = {
+type ReposUpdateBranchProtectionParamsRequiredStatusChecks = {
   strict: boolean;
   contexts: string[];
 };
-export type ReposUpdateBranchProtectionParamsRequiredPullRequestReviews = {
+type ReposUpdateBranchProtectionParamsRequiredPullRequestReviews = {
   dismissal_restrictions?: ReposUpdateBranchProtectionParamsRequiredPullRequestReviewsDismissalRestrictions;
   dismiss_stale_reviews?: boolean;
   require_code_owner_reviews?: boolean;
   required_approving_review_count?: number;
 };
-export type ReposUpdateBranchProtectionParamsRequiredPullRequestReviewsDismissalRestrictions = {
+type ReposUpdateBranchProtectionParamsRequiredPullRequestReviewsDismissalRestrictions = {
   users?: string[];
   teams?: string[];
 };
-export type ReposUpdateBranchProtectionParamsRestrictions = {
+type ReposUpdateBranchProtectionParamsRestrictions = {
   users: string[];
   teams: string[];
   apps?: string[];
 };
-export type ReposUpdateProtectedBranchPullRequestReviewEnforcementParamsDismissalRestrictions = {
+type ReposUpdateProtectedBranchPullRequestReviewEnforcementParamsDismissalRestrictions = {
   users?: string[];
   teams?: string[];
 };
-export type ChecksCreateParamsOutput = {
+type ChecksCreateParamsOutput = {
   title: string;
   summary: string;
   text?: string;
   annotations?: ChecksCreateParamsOutputAnnotations[];
   images?: ChecksCreateParamsOutputImages[];
 };
-export type ChecksCreateParamsOutputAnnotations = {
+type ChecksCreateParamsOutputAnnotations = {
   path: string;
   start_line: number;
   end_line: number;
@@ -42492,24 +42492,24 @@ export type ChecksCreateParamsOutputAnnotations = {
   title?: string;
   raw_details?: string;
 };
-export type ChecksCreateParamsOutputImages = {
+type ChecksCreateParamsOutputImages = {
   alt: string;
   image_url: string;
   caption?: string;
 };
-export type ChecksCreateParamsActions = {
+type ChecksCreateParamsActions = {
   label: string;
   description: string;
   identifier: string;
 };
-export type ChecksUpdateParamsOutput = {
+type ChecksUpdateParamsOutput = {
   title?: string;
   summary: string;
   text?: string;
   annotations?: ChecksUpdateParamsOutputAnnotations[];
   images?: ChecksUpdateParamsOutputImages[];
 };
-export type ChecksUpdateParamsOutputAnnotations = {
+type ChecksUpdateParamsOutputAnnotations = {
   path: string;
   start_line: number;
   end_line: number;
@@ -42520,81 +42520,81 @@ export type ChecksUpdateParamsOutputAnnotations = {
   title?: string;
   raw_details?: string;
 };
-export type ChecksUpdateParamsOutputImages = {
+type ChecksUpdateParamsOutputImages = {
   alt: string;
   image_url: string;
   caption?: string;
 };
-export type ChecksUpdateParamsActions = {
+type ChecksUpdateParamsActions = {
   label: string;
   description: string;
   identifier: string;
 };
-export type ChecksSetSuitesPreferencesParamsAutoTriggerChecks = {
+type ChecksSetSuitesPreferencesParamsAutoTriggerChecks = {
   app_id: number;
   setting: boolean;
 };
-export type ReposCreateOrUpdateFileParamsCommitter = {
+type ReposCreateOrUpdateFileParamsCommitter = {
   name: string;
   email: string;
 };
-export type ReposCreateOrUpdateFileParamsAuthor = {
+type ReposCreateOrUpdateFileParamsAuthor = {
   name: string;
   email: string;
 };
-export type ReposDeleteFileParamsCommitter = {
+type ReposDeleteFileParamsCommitter = {
   name?: string;
   email?: string;
 };
-export type ReposDeleteFileParamsAuthor = {
+type ReposDeleteFileParamsAuthor = {
   name?: string;
   email?: string;
 };
-export type ReposCreateDispatchEventParamsClientPayload = {};
-export type GitCreateCommitParamsAuthor = {
-  name?: string;
-  email?: string;
-  date?: string;
-};
-export type GitCreateCommitParamsCommitter = {
+type ReposCreateDispatchEventParamsClientPayload = {};
+type GitCreateCommitParamsAuthor = {
   name?: string;
   email?: string;
   date?: string;
 };
-export type GitCreateTagParamsTagger = {
+type GitCreateCommitParamsCommitter = {
   name?: string;
   email?: string;
   date?: string;
 };
-export type GitCreateTreeParamsTree = {
+type GitCreateTagParamsTagger = {
+  name?: string;
+  email?: string;
+  date?: string;
+};
+type GitCreateTreeParamsTree = {
   path?: string;
   mode?: "100644" | "100755" | "040000" | "160000" | "120000";
   type?: "blob" | "tree" | "commit";
   sha?: string | null;
   content?: string;
 };
-export type ReposCreateHookParamsConfig = {
+type ReposCreateHookParamsConfig = {
   url: string;
   content_type?: string;
   secret?: string;
   insecure_ssl?: string;
 };
-export type ReposUpdateHookParamsConfig = {
+type ReposUpdateHookParamsConfig = {
   url: string;
   content_type?: string;
   secret?: string;
   insecure_ssl?: string;
 };
-export type ReposEnablePagesSiteParamsSource = {
+type ReposEnablePagesSiteParamsSource = {
   branch?: "master" | "gh-pages";
   path?: string;
 };
-export type PullsCreateReviewParamsComments = {
+type PullsCreateReviewParamsComments = {
   path: string;
   position: number;
   body: string;
 };
-export type TeamsCreateOrUpdateIdPGroupConnectionsLegacyParamsGroups = {
+type TeamsCreateOrUpdateIdPGroupConnectionsLegacyParamsGroups = {
   group_id: string;
   group_name: string;
   group_description: string;

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,5 @@
 // This code is not executed, only statically analyzed using `tsc --noEmit`
-import { EndpointInterface, RequestMethod } from "./src";
+import { EndpointInterface, RequestMethod, RequestInterface } from "./src";
 
 const endpoint = null as EndpointInterface;
 
@@ -24,7 +24,9 @@ assertRequestMethod(test4.DEFAULTS.method);
 
 const result4 = test4({ method: "PUT", url: "/funk", headers: { foo: "bar" } });
 assertString(result4.headers.foo);
-// assert that "url" is optional if its set on defaults
+// "url" parameter is required
+// endpoint({});
+// "url" is optional if set on defaults
 assertString(test4({}).url);
 
 const test5 = test4.defaults({
@@ -74,4 +76,15 @@ const staticParseResult = endpoint.parse({
 
 assertString(staticParseResult.headers["x-foo"]);
 
-endpoint({});
+const request = null as RequestInterface;
+
+const rtest = request.defaults(fooOptions);
+const rtest2 = rtest.defaults(bazOptions);
+const rtest3 = rtest2.defaults(overrideOptions);
+const rtest4 = rtest3.defaults(routeOptions);
+
+assertString(rtest.endpoint.DEFAULTS.foo);
+assertString(rtest2.endpoint.DEFAULTS.foo);
+assertString(rtest2.endpoint.DEFAULTS.baz);
+assertString(rtest3.endpoint.DEFAULTS.foo);
+assertRequestMethod(rtest4.endpoint.DEFAULTS.method);

--- a/test.ts
+++ b/test.ts
@@ -1,0 +1,73 @@
+// This code is not executed, only statically analyzed using `tsc --noEmit`
+import { EndpointInterface, RequestMethod } from "./src";
+
+const endpoint = null as EndpointInterface;
+
+const fooOptions = { foo: "bar" };
+const bazOptions = { baz: "daz" };
+const overrideOptions = { foo: "newbar" };
+const routeOptions = { method: "GET", url: "/foo" };
+
+const test = endpoint.defaults(fooOptions);
+const test2 = test.defaults(bazOptions);
+const test3 = test2.defaults(overrideOptions);
+const test4 = test3.defaults(routeOptions);
+
+function assertString(type: string) {}
+function assertRequestMethod(type: RequestMethod) {}
+
+assertString(test.DEFAULTS.foo);
+assertString(test2.DEFAULTS.foo);
+assertString(test2.DEFAULTS.baz);
+assertString(test3.DEFAULTS.foo);
+assertRequestMethod(test4.DEFAULTS.method);
+
+const result4 = test4({ method: "PUT", url: "/funk", headers: { foo: "bar" } });
+assertString(result4.headers.foo);
+
+const test5 = test4.defaults({
+  method: "PUT",
+  url: "/funk",
+  headers: { foo: "bar" },
+});
+
+assertRequestMethod(test5({}).method);
+assertString(test5({}).url);
+assertString(test5({}).headers.foo);
+
+const createIssueOptions = {
+  owner: "octocat",
+  repo: "hello-world",
+  title: "My new issue!",
+  headers: {
+    "x-foo": "bar",
+  },
+};
+const result5 = test5("POST /repos/:owner/:repo/issues", createIssueOptions);
+const result5merge = test5.merge(
+  "POST /repos/:owner/:repo/issues",
+  createIssueOptions
+);
+const result5merge2 = test5.merge(createIssueOptions);
+
+assertString(result5.headers["x-foo"]);
+assertString(result5merge.title);
+assertString(result5merge.headers["x-foo"]);
+assertString(result5merge2.url);
+
+const staticParseResult = endpoint.parse({
+  baseUrl: "https://api.github.com",
+  method: "GET",
+  url: "/funk",
+  mediaType: {
+    format: "",
+    previews: [],
+  },
+  headers: {
+    "user-agent": "MyApp/1.2.3",
+    accept: "foo",
+    "x-foo": "bar",
+  },
+});
+
+assertString(staticParseResult.headers["x-foo"]);

--- a/test.ts
+++ b/test.ts
@@ -24,6 +24,8 @@ assertRequestMethod(test4.DEFAULTS.method);
 
 const result4 = test4({ method: "PUT", url: "/funk", headers: { foo: "bar" } });
 assertString(result4.headers.foo);
+// assert that "url" is optional if its set on defaults
+assertString(test4({}).url);
 
 const test5 = test4.defaults({
   method: "PUT",
@@ -71,3 +73,5 @@ const staticParseResult = endpoint.parse({
 });
 
 assertString(staticParseResult.headers["x-foo"]);
+
+endpoint({});


### PR DESCRIPTION
Defaults from `.endpoint.defaults(options)` and `.request.defaults(options)` are now passed on.

For example, before

```ts
import { EndpointInterface } from "@octokit/types";

const endpoint = null as EndpointInterface;
const fooOptions = { foo: "bar" };
endpoint.defaults(fooOptions).DEFAULTS.foo;
// type: any
```

after

```ts
import { EndpointInterface } from "@octokit/types";

const endpoint = null as EndpointInterface;
const fooOptions = { foo: "bar" };
endpoint.defaults(fooOptions).DEFAULTS.foo;
// type: string
```