### PR TITLE
types: add workaround for uploadReleaseAsset

### DIFF
--- a/scripts/update-endpoints/typescript.js
+++ b/scripts/update-endpoints/typescript.js
@@ -149,6 +149,9 @@ async function run() {
           "For https://api.github.com, set `baseUrl` to `https://uploads.github.com`. For GitHub Enterprise Server, set it to `<your hostname>/api/uploads`",
         required: true,
       });
+
+      const data = parameters.find((parameter) => parameter.name === "data");
+      data.type = "string | Buffer";
     }
 
     options.push({

--- a/scripts/update-endpoints/typescript.js
+++ b/scripts/update-endpoints/typescript.js
@@ -140,8 +140,10 @@ async function run() {
     }, undefined);
 
     const extraParameters = [];
-    // baseUrl must be set for "Upload a release asset"
+
+    // workarounds for "Upload a release asset"
     if (optionsTypeName === "ReposUploadReleaseAssetEndpoint") {
+      // baseUrl must be set for "Upload a release asset"
       extraParameters.push({
         name: "baseUrl",
         type: "string",
@@ -150,6 +152,7 @@ async function run() {
         required: true,
       });
 
+      // data can be either a string or Buffer. Currently the OpenAPI types only specify a type of string.
       const data = parameters.find((parameter) => parameter.name === "data");
       data.type = "string | Buffer";
     }

--- a/src/generated/Endpoints.ts
+++ b/src/generated/Endpoints.ts
@@ -34992,7 +34992,7 @@ type ReposUploadReleaseAssetEndpoint = {
   /**
    * The raw file data
    */
-  data: string;
+  data: string | Buffer;
   /**
    * The URL origin (protocol + host name + port) is included in `upload_url` returned in the response of the "Create a release" endpoint
    */


### PR DESCRIPTION
This adds a workaround in typescript.js to override the data parameter
type for ReposUploadReleaseAssetEndpoint. The endpoint type from the
openapi graphql server only specifies  string as a type, when it can
take a string or a Buffer.

Closes #73 