### PR TITLE
fix: response.data type should not  be unknown if endpoint has both `20x` and `301`/`302` response types

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -1,8 +1,9 @@
 // This code is not executed, only statically analyzed using `tsc --noEmit`
-import { EndpointInterface } from "./src";
+import { EndpointInterface, Endpoints } from "./src";
 
 const endpoint = null as EndpointInterface;
 function assertString(type: string) {}
+function assertArray(type: unknown[]) {}
 
 const createIssueOptions = {
   owner: "octocat",
@@ -26,3 +27,9 @@ assertString(result.headers["x-foo"]);
 assertString(resultMerge.title);
 assertString(resultMerge.headers["x-foo"]);
 assertString(resultMerge2.url);
+
+const test = {} as Endpoints["GET /repos/{owner}/{repo}/issues"]["response"];
+assertArray(test.data);
+assertString(test.data[0].assignees[0].avatar_url);
+const test2 = {} as Endpoints["GET /scim/v2/organizations/{org}/Users"]["response"];
+assertString(test2.data.Resources[0].name.givenName);


### PR DESCRIPTION
fixes #219