### PR TITLE
fix: set `"octokit"` key on published package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9302,6 +9302,12 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
       "dev": true
     },
+    "pika-plugin-merge-properties": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pika-plugin-merge-properties/-/pika-plugin-merge-properties-1.0.6.tgz",
+      "integrity": "sha512-GP6hx9cxRyMgsVNf2W0u6OoEUNVfonEi1NOBMmKVzZ5/Kd4xrBTncvrdHRG1RAJTkWCIDBp+tWSI7aYzFnzZCA==",
+      "dev": true
+    },
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "npm-run-all": "^4.1.5",
     "openapi-typescript": "^2.3.1",
     "pascal-case": "^3.1.1",
+    "pika-plugin-merge-properties": "^1.0.6",
     "prettier": "^2.0.0",
     "semantic-release": "^17.0.0",
     "semantic-release-plugin-update-version-in-files": "^1.0.0",
@@ -55,6 +56,14 @@
     "pipeline": [
       [
         "@pika/plugin-ts-standard-pkg"
+      ],
+      [
+        "pika-plugin-merge-properties",
+        {
+          "properties": {
+            "octokit": "see https://github.com/jabuco/pika-plugin-merge-properties/issues/2"
+          }
+        }
       ],
       [
         "@pika/plugin-build-node"


### PR DESCRIPTION
see https://github.com/jabuco/pika-plugin-merge-properties/issues/2 on why we set properties to an object instead of an array