### PR TITLE
fix: remove dependency on "http" types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1608,7 +1608,8 @@
     "@types/node": {
       "version": "14.14.25",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.25.tgz",
-      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ=="
+      "integrity": "sha512-EPpXLOVqDvisVxtlbvzfyqSsFeQxltFbluZNRndIb8tr9KiBnYNLzrc1N3pyKUCww2RNrfHDViqDWWE1LCJQtQ==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   },
   "description": "Shared TypeScript definitions for Octokit projects",
   "dependencies": {
-    "@octokit/openapi-types": "^4.0.3",
-    "@types/node": ">= 8"
+    "@octokit/openapi-types": "^4.0.3"
   },
   "scripts": {
     "build": "pika build",
@@ -37,6 +36,7 @@
     "@pika/plugin-build-node": "^0.9.0",
     "@pika/plugin-build-web": "^0.9.0",
     "@pika/plugin-ts-standard-pkg": "^0.9.0",
+    "@types/node": ">= 8",
     "handlebars": "^4.7.6",
     "json-schema-to-typescript": "^10.0.0",
     "lodash.set": "^4.3.2",

--- a/src/RequestRequestOptions.ts
+++ b/src/RequestRequestOptions.ts
@@ -1,4 +1,3 @@
-import { Agent } from "http";
 import { Fetch } from "./Fetch";
 import { Signal } from "./Signal";
 
@@ -8,8 +7,10 @@ import { Signal } from "./Signal";
 export type RequestRequestOptions = {
   /**
    * Node only. Useful for custom proxy, certificate, or dns lookup.
+   *
+   * @see https://nodejs.org/api/http.html#http_class_http_agent
    */
-  agent?: Agent;
+  agent?: unknown;
   /**
    * Custom replacement for built-in fetch method. Useful for testing or request hooks.
    */


### PR DESCRIPTION
This will help us with making Octokit work with Deno via skypack. See https://github.com/skypackjs/skypack-cdn/issues/134