### PR TITLE
fix: `POST /repos/{owner}/{repo}/forks` has a `never` response type

### DIFF
--- a/scripts/update-endpoints/templates/endpoints.ts.template
+++ b/scripts/update-endpoints/templates/endpoints.ts.template
@@ -72,7 +72,7 @@ type MethodsMap = {
   post: "POST";
   put: "PUT";
 };
-type SuccessStatuses = 200 | 201 | 204;
+type SuccessStatuses = 200 | 201 | 202 | 204;
 type RedirectStatuses = 301 | 302;
 type EmptyResponseStatuses = 201 | 204;
 type KnownJsonResponseTypes =

--- a/src/generated/Endpoints.ts
+++ b/src/generated/Endpoints.ts
@@ -72,7 +72,7 @@ type MethodsMap = {
   post: "POST";
   put: "PUT";
 };
-type SuccessStatuses = 200 | 201 | 204;
+type SuccessStatuses = 200 | 201 | 202 | 204;
 type RedirectStatuses = 301 | 302;
 type EmptyResponseStatuses = 201 | 204;
 type KnownJsonResponseTypes =


### PR DESCRIPTION
Fixes #271