### PR TITLE
fix: remove response types workaround for required keys (#214)

### DIFF
--- a/src/generated/Endpoints.ts
+++ b/src/generated/Endpoints.ts
@@ -58,11 +58,7 @@ type Operation<
     headers: RequestHeaders;
     request: RequestRequestOptions;
   };
-  response: Url extends keyof EndpointsWithMissingRequiredResponseDataSchema
-    ? Method extends EndpointsWithMissingRequiredResponseDataSchema[Url]
-      ? DeepRequired<ExtractOctokitResponse<paths[Url][Method]>>
-      : ExtractOctokitResponse<paths[Url][Method]>
-    : ExtractOctokitResponse<paths[Url][Method]>;
+  response: ExtractOctokitResponse<paths[Url][Method]>;
 };
 
 type MethodsMap = {
@@ -107,136 +103,6 @@ type ExtractOctokitResponse<R> = "responses" extends keyof R
       : RedirectResponseDataType<R["responses"]>
     : SuccessResponseDataType<R["responses"]>
   : unknown;
-
-// Workaround incorrect response types
-// https://github.com/octokit/types.ts/issues/214
-type EndpointsWithMissingRequiredResponseDataSchema = {
-  "/app/hook/config": "get" | "patch";
-  "/app/installations/{installation_id}/access_tokens": "post";
-  "/emojis": "get";
-  "/enterprises/{enterprise}/actions/permissions": "get";
-  "/enterprises/{enterprise}/actions/permissions/organizations": "get";
-  "/enterprises/{enterprise}/actions/permissions/selected-actions": "get";
-  "/enterprises/{enterprise}/actions/runner-groups": "get" | "post";
-  "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}":
-    | "get"
-    | "patch";
-  "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations": "get";
-  "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners": "get";
-  "/enterprises/{enterprise}/actions/runners": "get";
-  "/enterprises/{enterprise}/actions/runners/downloads": "get";
-  "/enterprises/{enterprise}/settings/billing/actions": "get";
-  "/enterprises/{enterprise}/settings/billing/packages": "get";
-  "/enterprises/{enterprise}/settings/billing/shared-storage": "get";
-  "/installation/repositories": "get";
-  "/notifications": "get";
-  "/notifications/threads/{thread_id}": "get";
-  "/orgs/{org}/actions/permissions": "get";
-  "/orgs/{org}/actions/permissions/repositories": "get";
-  "/orgs/{org}/actions/permissions/selected-actions": "get";
-  "/orgs/{org}/actions/runner-groups": "get" | "post";
-  "/orgs/{org}/actions/runner-groups/{runner_group_id}": "get" | "patch";
-  "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories": "get";
-  "/orgs/{org}/actions/runner-groups/{runner_group_id}/runners": "get";
-  "/orgs/{org}/actions/runners": "get";
-  "/orgs/{org}/actions/runners/downloads": "get";
-  "/orgs/{org}/actions/secrets": "get";
-  "/orgs/{org}/actions/secrets/{secret_name}/repositories": "get";
-  "/orgs/{org}/hooks/{hook_id}/config": "get" | "patch";
-  "/orgs/{org}/installations": "get";
-  "/orgs/{org}/invitations": "get" | "post";
-  "/orgs/{org}/settings/billing/actions": "get";
-  "/orgs/{org}/settings/billing/packages": "get";
-  "/orgs/{org}/settings/billing/shared-storage": "get";
-  "/orgs/{org}/team-sync/groups": "get";
-  "/orgs/{org}/teams/{team_slug}/invitations": "get";
-  "/orgs/{org}/teams/{team_slug}/projects": "get";
-  "/orgs/{org}/teams/{team_slug}/projects/{project_id}": "get";
-  "/orgs/{org}/teams/{team_slug}/team-sync/group-mappings": "get" | "patch";
-  "/projects/columns/cards/{card_id}/moves": "post";
-  "/projects/columns/{column_id}/moves": "post";
-  "/repos/{owner}/{repo}/actions/artifacts": "get";
-  "/repos/{owner}/{repo}/actions/permissions": "get";
-  "/repos/{owner}/{repo}/actions/permissions/selected-actions": "get";
-  "/repos/{owner}/{repo}/actions/runners": "get";
-  "/repos/{owner}/{repo}/actions/runners/downloads": "get";
-  "/repos/{owner}/{repo}/actions/runs": "get";
-  "/repos/{owner}/{repo}/actions/runs/{run_id}/artifacts": "get";
-  "/repos/{owner}/{repo}/actions/runs/{run_id}/jobs": "get";
-  "/repos/{owner}/{repo}/actions/runs/{run_id}/timing": "get";
-  "/repos/{owner}/{repo}/actions/secrets": "get";
-  "/repos/{owner}/{repo}/actions/workflows": "get";
-  "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs": "get";
-  "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing": "get";
-  "/repos/{owner}/{repo}/check-suites/preferences": "patch";
-  "/repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs": "get";
-  "/repos/{owner}/{repo}/code-scanning/alerts": "get";
-  "/repos/{owner}/{repo}/code-scanning/alerts/{alert_number}": "get" | "patch";
-  "/repos/{owner}/{repo}/code-scanning/analyses": "get";
-  "/repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head": "get";
-  "/repos/{owner}/{repo}/commits/{ref}/check-runs": "get";
-  "/repos/{owner}/{repo}/commits/{ref}/check-suites": "get";
-  "/repos/{owner}/{repo}/commits/{ref}/statuses": "get";
-  "/repos/{owner}/{repo}/contents/{path}": "put" | "delete";
-  "/repos/{owner}/{repo}/git/blobs": "post";
-  "/repos/{owner}/{repo}/git/commits": "post";
-  "/repos/{owner}/{repo}/git/commits/{commit_sha}": "get";
-  "/repos/{owner}/{repo}/git/matching-refs/{ref}": "get";
-  "/repos/{owner}/{repo}/git/ref/{ref}": "get";
-  "/repos/{owner}/{repo}/git/refs": "post";
-  "/repos/{owner}/{repo}/git/refs/{ref}": "patch";
-  "/repos/{owner}/{repo}/hooks/{hook_id}/config": "get" | "patch";
-  "/repos/{owner}/{repo}/issues/{issue_number}/events": "get";
-  "/repos/{owner}/{repo}/issues/{issue_number}/timeline": "get";
-  "/repos/{owner}/{repo}/keys": "get" | "post";
-  "/repos/{owner}/{repo}/keys/{key_id}": "get";
-  "/repos/{owner}/{repo}/languages": "get";
-  "/repos/{owner}/{repo}/notifications": "get";
-  "/repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers": "get";
-  "/repos/{owner}/{repo}/stats/participation": "get";
-  "/repos/{owner}/{repo}/statuses/{sha}": "post";
-  "/repos/{owner}/{repo}/topics": "get" | "put";
-  "/scim/v2/enterprises/{enterprise}/Groups": "get" | "post";
-  "/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}":
-    | "get"
-    | "put"
-    | "patch";
-  "/scim/v2/enterprises/{enterprise}/Users": "get" | "post";
-  "/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}":
-    | "get"
-    | "put"
-    | "patch";
-  "/search/code": "get";
-  "/search/commits": "get";
-  "/search/issues": "get";
-  "/search/labels": "get";
-  "/search/repositories": "get";
-  "/search/topics": "get";
-  "/search/users": "get";
-  "/teams/{team_id}/invitations": "get";
-  "/teams/{team_id}/projects": "get";
-  "/teams/{team_id}/projects/{project_id}": "get";
-  "/teams/{team_id}/team-sync/group-mappings": "get" | "patch";
-  "/user/installations": "get";
-  "/user/installations/{installation_id}/repositories": "get";
-  "/user/keys": "get" | "post";
-  "/user/keys/{key_id}": "get";
-  "/users/{username}/settings/billing/actions": "get";
-  "/users/{username}/settings/billing/packages": "get";
-  "/users/{username}/settings/billing/shared-storage": "get";
-};
-// https://gist.github.com/esamattis/70e9c780e08937cb0b016e04a7422010
-type NotNill<T> = T extends null | undefined ? never : T;
-type Primitive = undefined | null | boolean | string | number | Function;
-type DeepRequired<T> = T extends Primitive
-  ? NotNill<T>
-  : {
-      [P in keyof T]-?: T[P] extends Array<infer U>
-        ? Array<DeepRequired<U>>
-        : T[P] extends ReadonlyArray<infer U2>
-        ? DeepRequired<U2>
-        : DeepRequired<T[P]>;
-    };
 
 export interface Endpoints {
   /**


### PR DESCRIPTION
follow up to #214 and https://github.com/github/rest-api-description/issues/109
