### PR TITLE
fix(deps): bump `@octokit/openapi-types` to v9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1264,9 +1264,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz",
-      "integrity": "sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.0.0.tgz",
+      "integrity": "sha512-GSpv5VUFqarOXZl6uWPsDnjChkKCxnaMALmQhzvCWGiMxONQxX7ZwlomCMS+wB1KqxLPCA5n6gYt016oEMkHmQ=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.14.0",
@@ -1337,6 +1337,14 @@
       "dev": true,
       "requires": {
         "@octokit/openapi-types": "^8.3.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-8.3.0.tgz",
+          "integrity": "sha512-ZFyQ30tNpoATI7o+Z9MWFUzUgWisB8yduhcky7S4UYsRijgIGSnwUKzPBDGzf/Xkx1DuvUtqzvmuFlDSqPJqmQ==",
+          "dev": true
+        }
       }
     },
     "@pika/babel-plugin-esm-import-rewrite": {
@@ -6731,8 +6739,8 @@
             "binary-extensions": "^2.2.0",
             "diff": "^5.0.0",
             "minimatch": "^3.0.4",
-            "npm-package-arg": "^8.1.4",
-            "pacote": "^11.3.4",
+            "npm-package-arg": "^8.1.1",
+            "pacote": "^11.3.0",
             "tar": "^6.1.0"
           }
         },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "Shared TypeScript definitions for Octokit projects",
   "dependencies": {
-    "@octokit/openapi-types": "^8.3.0"
+    "@octokit/openapi-types": "^9.0.0"
   },
   "scripts": {
     "build": "pika build",
@@ -96,7 +96,7 @@
     ]
   },
   "octokit": {
-    "openapi-version": "2.25.0"
+    "openapi-version": "3.0.0"
   },
   "renovate": {
     "extends": [


### PR DESCRIPTION
`@octokit/openapi-types` v9 changed all component keys with `_` to use `-`. `@octokit/types` is not exposing these properties to a fix release is enough