### PR TITLE
fix: `POST /repos/{owner}/{repo}/releases/{release_id}/assets`: `name` query parameter is required. `head.repo` is nullable in `pull-request` schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1264,9 +1264,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.1.0.tgz",
-      "integrity": "sha512-XBP03pG4XuTU+VgeJM1ozRdmZJerMG4tk6wA+raFKycC4qV9jtD2UQroAg9bAcmI3Q0zWvifeDGtPqsFjMzkLg=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-9.1.1.tgz",
+      "integrity": "sha512-xmyPP9tVb4T4A6Lk6SL6ScnIqAHpPV4jfMZI8VtY286212ri9J/6IFGuLsZ26daADUmriuLejake4k+azEfnaw=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "2.14.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "Shared TypeScript definitions for Octokit projects",
   "dependencies": {
-    "@octokit/openapi-types": "^9.1.0"
+    "@octokit/openapi-types": "^9.1.1"
   },
   "scripts": {
     "build": "pika build",
@@ -96,7 +96,7 @@
     ]
   },
   "octokit": {
-    "openapi-version": "3.1.0"
+    "openapi-version": "3.1.2"
   },
   "renovate": {
     "extends": [


### PR DESCRIPTION
- fix(deps): bump `@octokit/types` to `^9.1.1`
- build(package): lock file
