### PR TITLE
ci(codeql): ignore on push events for dependabot branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,8 @@ name: "Code scanning - action"
 
 on:
   push:
+      branches-ignore:
+      - "dependabot/**"
   pull_request:
   schedule:
     - cron: '0 19 * * 0'


### PR DESCRIPTION
Fixes #388 