### PR TITLE
fix(RequestInterface): make types with VS Code Typeahead and TypeScript 4.7

### DIFF
--- a/src/RequestInterface.ts
+++ b/src/RequestInterface.ts
@@ -23,14 +23,18 @@ export interface RequestInterface<D extends object = object> {
    * @param {string} route Request method + URL. Example: `'GET /orgs/{org}'`
    * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  <R extends Route>(
-    route: keyof Endpoints | R,
-    options?: R extends keyof Endpoints
-      ? Endpoints[R]["parameters"] & RequestParameters
-      : RequestParameters
-  ): R extends keyof Endpoints
-    ? Promise<Endpoints[R]["response"]>
-    : Promise<OctokitResponse<any>>;
+  <R extends keyof Endpoints>(
+    route: R,
+    options?: Endpoints[R]["parameters"] & RequestParameters
+  ): Promise<Endpoints[R]["response"]>;
+
+  /**
+   * Sends a request based on endpoint options
+   *
+   * @param {string} route Request method + URL. Example: `'GET /orgs/{org}'`
+   * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
+   */
+  (route: Route, options?: RequestParameters): Promise<OctokitResponse<any>>;
 
   /**
    * Returns a new `request` with updated route and parameters


### PR DESCRIPTION
## Description
This PR attempts to address https://github.com/octokit/core.js/issues/469 (route auto suggestion is not triggered).

The request definition was split to two overloads: one for known routes (`keyof Endpoints`) and another one for "catch all" `Route` (any `string`)

## Additional info
The autocomplete stopped working in Typescript 4.7, but I couldn't find anything related in release notes.

---

Closes https://github.com/octokit/core.js/issues/469