### PR TITLE
fix(RequestInterface): restore catch all overload

### DIFF
--- a/src/RequestInterface.ts
+++ b/src/RequestInterface.ts
@@ -34,7 +34,14 @@ export interface RequestInterface<D extends object = object> {
    * @param {string} route Request method + URL. Example: `'GET /orgs/{org}'`
    * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  (route: Route, options?: RequestParameters): Promise<OctokitResponse<any>>;
+  <R extends Route>(
+    route: keyof Endpoints | R,
+    options?: R extends keyof Endpoints
+      ? Endpoints[R]["parameters"] & RequestParameters
+      : RequestParameters
+  ): R extends keyof Endpoints
+    ? Promise<Endpoints[R]["response"]>
+    : Promise<OctokitResponse<any>>;
 
   /**
    * Returns a new `request` with updated route and parameters


### PR DESCRIPTION
## Description

https://github.com/octokit/types.ts/pull/399 fixed routes autocompletion, but request options resolution was broken as a result. TypeScript selected second non generic overload once `{}` was provided as the `options` parameter.

This PR restores previous generic version which accepts both known/predefined and dynamic routes (in addition to overload that accepts only known routes), so TS will always try to resolve request options type according to provided route.

---

Closes https://github.com/octokit/core.js/issues/486

** Maybe it worth opening issue in TypeScript and try to understand why existing solution stopped working since 4.7