### PR TITLE
fix(RequestInterface): Revert method overloading with adding some tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "prettier --check '{src,test,scripts}/**/*.{js,ts,json}' README.md package.json !src/generated/* !scripts/update-endpoints/generated/*",
     "lint:fix": "prettier --write '{src,test,scripts}/**/*.{js,ts,json}' README.md package.json !src/generated/* !scripts/update-endpoints/generated/*",
     "pretest": "npm run -s lint",
-    "test": "npx tsc --noEmit --declaration --noUnusedLocals src/index.ts test.ts",
+    "test": "npx tsc --project tsconfig.test.json",
     "update-endpoints": "npm-run-all update-endpoints:*",
     "update-endpoints:fetch-json": "node scripts/update-endpoints/fetch-json",
     "update-endpoints:typescript": "node scripts/update-endpoints/typescript",

--- a/src/RequestInterface.ts
+++ b/src/RequestInterface.ts
@@ -34,7 +34,14 @@ export interface RequestInterface<D extends object = object> {
    * @param {string} route Request method + URL. Example: `'GET /orgs/{org}'`
    * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
-  (route: Route, options?: RequestParameters): Promise<OctokitResponse<any>>;
+  <R extends Route>(
+    route: keyof Endpoints | R,
+    options?: R extends keyof Endpoints
+      ? Endpoints[R]["parameters"] & RequestParameters
+      : RequestParameters
+  ): R extends keyof Endpoints
+    ? Promise<Endpoints[R]["response"]>
+    : Promise<OctokitResponse<any>>;
 
   /**
    * Returns a new `request` with updated route and parameters

--- a/test.ts
+++ b/test.ts
@@ -1,8 +1,9 @@
 // This code is not executed, only statically analyzed using `tsc --noEmit`
 import { EndpointInterface, Endpoints } from "./src";
 
-const endpoint = null as EndpointInterface;
+const endpoint = {} as EndpointInterface;
 function assertString(type: string) {}
+function assertNullableString(type: string | null | undefined) {}
 function assertArray(type: unknown[]) {}
 
 const createIssueOptions = {
@@ -26,13 +27,13 @@ const resultMerge2 = endpoint.merge(createIssueOptions);
 assertString(result.headers["x-foo"]);
 assertString(resultMerge.title);
 assertString(resultMerge.headers["x-foo"]);
-assertString(resultMerge2.url);
+assertNullableString(resultMerge2.url);
 
 const test = {} as Endpoints["GET /repos/{owner}/{repo}/issues"]["response"];
 assertArray(test.data);
-assertString(test.data[0].assignees[0].avatar_url);
+assertString(test.data[0].assignees![0].avatar_url);
 const test2 = {} as Endpoints["GET /scim/v2/organizations/{org}/Users"]["response"];
-assertString(test2.data.Resources[0].name.givenName);
+assertNullableString(test2.data.Resources[0].name.givenName);
 
 const test3 = {} as Endpoints["POST /user/repos"]["parameters"];
 assertString(test3.name);

--- a/test.ts
+++ b/test.ts
@@ -1,10 +1,14 @@
 // This code is not executed, only statically analyzed using `tsc --noEmit`
-import { EndpointInterface, Endpoints } from "./src";
+import { EndpointInterface, Endpoints, RequestInterface, RequestParameters, Route } from "./src";
 
 const endpoint = {} as EndpointInterface;
 function assertString(type: string) {}
 function assertNullableString(type: string | null | undefined) {}
 function assertArray(type: unknown[]) {}
+const assertPaginate = {} as {
+  <R extends Route>(route: R): Promise<void>;
+  <R extends RequestInterface>(request: R): Promise<void>;
+};
 
 const createIssueOptions = {
   owner: "octocat",
@@ -37,3 +41,18 @@ assertNullableString(test2.data.Resources[0].name.givenName);
 
 const test3 = {} as Endpoints["POST /user/repos"]["parameters"];
 assertString(test3.name);
+
+const checkRunsRoute = 'GET /repos/{owner}/{repo}/commits/{ref}/check-runs' as const;
+
+assertPaginate(checkRunsRoute);
+
+const listForRef = {} as {
+  (params?: RequestParameters & Omit<Endpoints["GET /repos/{owner}/{repo}/commits/{ref}/check-runs"]["parameters"], "baseUrl" | "headers" | "mediaType">): Promise<Endpoints[typeof checkRunsRoute]["response"]>;
+  defaults: RequestInterface["defaults"];
+  endpoint: EndpointInterface<{
+      url: string;
+  }>;
+};
+
+// octokit.paginate can take `request` method. ref: https://github.com/octokit/plugin-paginate-rest.js/blob/b3fb11e301f9658554e110aeebbd7cbb89b8aad4/README.md?plain=1#L117-L126
+assertPaginate(listForRef);

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": true,
+    "noUnusedLocals": true
+  },
+  "include": ["test.ts"]
+}


### PR DESCRIPTION
I have faced CI broken in `Bump @octokit/types from 6.37.0 to 6.37.1` ref: https://github.com/kachick/wait-other-jobs/runs/7064440245?check_suite_focus=true.

It looks type mismatch with https://github.com/octokit/plugin-paginate-rest.js.
Removing https://github.com/octokit/types.ts/blob/6e15b563f62196bab3b9b23b7d2f0f42c7be1c18/src/RequestInterface.ts#L37 passed typecheck, however I agree to revert as #404 at least in patch versions.

This PR is just a suggestion to includes the test. (Current test does not respect exists tsconfig.json, so some tests are already broken).

@levenleven I have cherry-picked your commit into this PR 🙏 
