### PR TITLE
ci: stop testing against NodeJS v10, v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,5 +106,8 @@
       "@octokit/openapi-types",
       "sort-keys"
     ]
+  },
+  "engines": {
+    "node": ">= 14"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Drop support for NodeJS v10, v12