### PR TITLE
Improve endpoint type example

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,11 @@ import {
 } from "@octokit/types";
 import { Octokit } from "@octokit/rest";
 
-const octokit = new Octokit();
 type CreateLabelResponseType = GetResponseTypeFromEndpointMethod<
-  typeof octokit.issues.createLabel
+  Octokit['issues']['createLabel']
 >;
 type CreateLabelResponseDataType = GetResponseDataTypeFromEndpointMethod<
-  typeof octokit.issues.createLabel
+  Octokit['issues']['createLabel']
 >;
 ```
 


### PR DESCRIPTION
In almost every case of using the types directly, I don't necessarily have an octokit instance in scope, so accessing the types without instantiating an instance is generally better practice. Updating the docs to show direct type access, I think, would help people avoid creating unnecessary instances, especially when they are less familiar with all of the ways you can access types in typescript.