### PR TITLE
fix(deps): revert upgrade of dependency `sort-keys` to v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "prettier": "^2.0.0",
         "semantic-release": "^19.0.3",
         "semantic-release-plugin-update-version-in-files": "^1.0.0",
-        "sort-keys": "^5.0.0",
+        "sort-keys": "^4.2.0",
         "string-to-jsdoc-comment": "^1.0.0",
         "typedoc": "^0.23.0",
         "typescript": "^4.0.2"
@@ -10057,30 +10057,27 @@
       }
     },
     "node_modules/sort-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.0.0.tgz",
-      "integrity": "sha512-Pdz01AvCAottHTPQGzndktFNdbRA75BgOfeT1hH+AMnJFv8lynkPi42rfeEhpx1saTEI3YNMWxfqu0sFD1G8pw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
+      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
       "dev": true,
       "dependencies": {
-        "is-plain-obj": "^4.0.0"
+        "is-plain-obj": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sort-keys/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true,
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/source-map": {
@@ -18395,18 +18392,18 @@
       "dev": true
     },
     "sort-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.0.0.tgz",
-      "integrity": "sha512-Pdz01AvCAottHTPQGzndktFNdbRA75BgOfeT1hH+AMnJFv8lynkPi42rfeEhpx1saTEI3YNMWxfqu0sFD1G8pw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
+      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^4.0.0"
+        "is-plain-obj": "^2.0.0"
       },
       "dependencies": {
         "is-plain-obj": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prettier": "^2.0.0",
     "semantic-release": "^19.0.3",
     "semantic-release-plugin-update-version-in-files": "^1.0.0",
-    "sort-keys": "^5.0.0",
+    "sort-keys": "^4.2.0",
     "string-to-jsdoc-comment": "^1.0.0",
     "typedoc": "^0.23.0",
     "typescript": "^4.0.2"


### PR DESCRIPTION
Reverts octokit/types.ts#467

This seems to have broken the "update" process because it's an ES module and we're using `require`. We can fix that at some point, but for now, let's revert.