### PR TITLE
feat: drop support for Enterprise Server and Enterprise Cloud-specific APIs, and add support for 10 new APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^13.11.0"
+        "@octokit/openapi-types": "^14.0.0"
       },
       "devDependencies": {
         "@pika/pack": "^0.3.7",
@@ -1938,9 +1938,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.13.1.tgz",
-      "integrity": "sha512-4EuKSk3N95UBWFau3Bz9b3pheQ8jQYbKmBL5+GSuY8YDPDwu03J4BjI+66yNi8aaX/3h1qDpb0mbBkLdr+cfGQ=="
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
+      "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "4.3.1",
@@ -2036,6 +2036,12 @@
       "dependencies": {
         "@octokit/openapi-types": "^13.11.0"
       }
+    },
+    "node_modules/@octokit/types/node_modules/@octokit/openapi-types": {
+      "version": "13.13.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.13.1.tgz",
+      "integrity": "sha512-4EuKSk3N95UBWFau3Bz9b3pheQ8jQYbKmBL5+GSuY8YDPDwu03J4BjI+66yNi8aaX/3h1qDpb0mbBkLdr+cfGQ==",
+      "dev": true
     },
     "node_modules/@pika/babel-plugin-esm-import-rewrite": {
       "version": "0.6.1",
@@ -12410,9 +12416,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "13.13.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.13.1.tgz",
-      "integrity": "sha512-4EuKSk3N95UBWFau3Bz9b3pheQ8jQYbKmBL5+GSuY8YDPDwu03J4BjI+66yNi8aaX/3h1qDpb0mbBkLdr+cfGQ=="
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-14.0.0.tgz",
+      "integrity": "sha512-HNWisMYlR8VCnNurDU6os2ikx0s0VyEjDYHNS/h4cgb8DeOxQ0n72HyinUtdDVxJhFy3FWLGl0DJhfEWk3P5Iw=="
     },
     "@octokit/plugin-paginate-rest": {
       "version": "4.3.1",
@@ -12484,6 +12490,14 @@
       "dev": true,
       "requires": {
         "@octokit/openapi-types": "^13.11.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "13.13.1",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.13.1.tgz",
+          "integrity": "sha512-4EuKSk3N95UBWFau3Bz9b3pheQ8jQYbKmBL5+GSuY8YDPDwu03J4BjI+66yNi8aaX/3h1qDpb0mbBkLdr+cfGQ==",
+          "dev": true
+        }
       }
     },
     "@pika/babel-plugin-esm-import-rewrite": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,6 @@
     ]
   },
   "octokit": {
-    "openapi-version": "7.13.0"
+    "openapi-version": "8.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "Shared TypeScript definitions for Octokit projects",
   "dependencies": {
-    "@octokit/openapi-types": "^13.11.0"
+    "@octokit/openapi-types": "^14.0.0"
   },
   "scripts": {
     "build": "pika-pack build",

--- a/scripts/update-endpoints/fetch-json.js
+++ b/scripts/update-endpoints/fetch-json.js
@@ -33,6 +33,18 @@ const QUERY = `
 
 main();
 
+// In order to see operations which are only available in GitHub Enterprise Cloud
+// (GHEC), `github-openapi-graphql-query` now looks at the GHEC-specific OpenAPI
+// specifications. At the moment, the documentation URLs, therefore, are not
+// normalised. This removes the references to GHEC.
+const removeEnterpriseCloudFromDocumentationUrl = (endpoint) => ({
+  ...endpoint,
+  documentationUrl: endpoint.documentationUrl.replace(
+    "/enterprise-cloud@latest/",
+    ""
+  ),
+});
+
 async function main() {
   const {
     data: { endpoints },
@@ -43,8 +55,11 @@ async function main() {
 
   writeFileSync(
     path.resolve(__dirname, "generated", "endpoints.json"),
-    prettier.format(JSON.stringify(endpoints), {
-      parser: "json",
-    })
+    prettier.format(
+      JSON.stringify(endpoints.map(removeEnterpriseCloudFromDocumentationUrl)),
+      {
+        parser: "json",
+      }
+    )
   );
 }

--- a/scripts/update-endpoints/fetch-json.js
+++ b/scripts/update-endpoints/fetch-json.js
@@ -12,7 +12,7 @@ const version = process.env.VERSION.replace(/^v/, "");
 
 const QUERY = `
   query ($version: String!, $ignoreChangesBefore: String!) {
-    endpoints(version: $version, ignoreChangesBefore: $ignoreChangesBefore) {
+    endpoints(version: $version, ignoreChangesBefore: $ignoreChangesBefore, filter: { isGithubCloudOnly: false }) {
       method
       url
       documentationUrl

--- a/scripts/update-endpoints/generated/endpoints.json
+++ b/scripts/update-endpoints/generated/endpoints.json
@@ -26,28 +26,6 @@
   },
   {
     "method": "PUT",
-    "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#add-repository-acess-to-a-self-hosted-runner-group-in-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "repository_id"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
     "url": "/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#add-selected-repository-to-an-organization-secret",
     "parameters": [
@@ -64,23 +42,6 @@
         "in": "PATH",
         "name": "repository_id"
       }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
-    "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#add-a-self-hosted-runner-to-a-group-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
     "previews": [],
     "renamed": null
@@ -241,43 +202,6 @@
   },
   {
     "method": "POST",
-    "url": "/orgs/{org}/actions/runner-groups",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#create-a-self-hosted-runner-group-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "name" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "visibility" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "selected_repository_ids"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "runners" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "allows_public_repositories"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "restricted_to_workflows"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "selected_workflows"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "POST",
     "url": "/repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#create-a-workflow-dispatch-event",
     "parameters": [
@@ -397,22 +321,6 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "DELETE",
-    "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#delete-a-self-hosted-runner-group-from-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      }
     ],
     "previews": [],
     "renamed": null
@@ -657,17 +565,6 @@
   },
   {
     "method": "GET",
-    "url": "/repos/{owner}/{repo}/actions/oidc/customization/sub",
-    "documentationUrl": "https://docs.github.com/rest/actions/oidc#get-the-opt-out-flag-of-an-oidc-subject-claim-customization-for-a-repository",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
     "url": "/repositories/{repository_id}/environments/{environment_name}/secrets/public-key",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#get-an-environment-public-key",
     "parameters": [
@@ -877,22 +774,6 @@
   },
   {
     "method": "GET",
-    "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#get-a-self-hosted-runner-group-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
     "url": "/repos/{owner}/{repo}/actions/workflows/{workflow_id}",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#get-a-workflow",
     "parameters": [
@@ -1088,24 +969,6 @@
   },
   {
     "method": "GET",
-    "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#list-repository-access-to-a-self-hosted-runner-group-in-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
     "url": "/repos/{owner}/{repo}/actions/secrets",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#list-repository-secrets",
     "parameters": [
@@ -1183,24 +1046,6 @@
   },
   {
     "method": "GET",
-    "url": "/orgs/{org}/actions/runner-groups",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#list-self-hosted-runner-groups-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "QUERY",
-        "name": "visible_to_repository"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
     "url": "/orgs/{org}/actions/runners",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#list-self-hosted-runners-for-an-organization",
     "parameters": [
@@ -1218,24 +1063,6 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#list-self-hosted-runners-in-a-group-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
@@ -1428,28 +1255,6 @@
   },
   {
     "method": "DELETE",
-    "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#remove-repository-access-to-a-self-hosted-runner-group-in-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "repository_id"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "DELETE",
     "url": "/orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#remove-selected-repository-from-an-organization-secret",
     "parameters": [
@@ -1471,23 +1276,6 @@
     "renamed": null
   },
   {
-    "method": "DELETE",
-    "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#remove-a-self-hosted-runner-from-a-group-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
     "method": "POST",
     "url": "/repos/{owner}/{repo}/actions/runs/{run_id}/pending_deployments",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#review-pending-deployments-for-a-workflow-run",
@@ -1503,22 +1291,6 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "state" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "comment" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
-    "url": "/enterprises/{enterprise}/actions/oidc/customization/issuer",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions/oidc#set-actions-oidc-custom-issuer-policy-for-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "include_enterprise_slug"
-      }
     ],
     "previews": [],
     "renamed": null
@@ -1601,18 +1373,6 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "labels" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
-    "url": "/repos/{owner}/{repo}/actions/oidc/customization/sub",
-    "documentationUrl": "https://docs.github.com/rest/actions/oidc#set-the-opt-out-flag-of-an-oidc-subject-claim-customization-for-a-repository",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "use_default" }
     ],
     "previews": [],
     "renamed": null
@@ -1726,28 +1486,6 @@
   },
   {
     "method": "PUT",
-    "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#set-repository-access-to-a-self-hosted-runner-group-in-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "selected_repository_ids"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
     "url": "/orgs/{org}/actions/secrets/{secret_name}/repositories",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#set-selected-repositories-for-an-organization-secret",
     "parameters": [
@@ -1786,23 +1524,6 @@
   },
   {
     "method": "PUT",
-    "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#set-self-hosted-runners-in-a-group-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "runners" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
     "url": "/repos/{owner}/{repo}/actions/permissions/access",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#set-workflow-access-to-a-repository",
     "parameters": [
@@ -1813,42 +1534,6 @@
         "deprecated": null,
         "in": "BODY",
         "name": "access_level"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PATCH",
-    "url": "/orgs/{org}/actions/runner-groups/{runner_group_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#update-a-self-hosted-runner-group-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "name" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "visibility" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "allows_public_repositories"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "restricted_to_workflows"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "selected_workflows"
       }
     ],
     "previews": [],
@@ -3166,33 +2851,6 @@
   },
   {
     "method": "GET",
-    "url": "/enterprises/{enterprise}/audit-log",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#get-the-audit-log-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "phrase" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "include" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "after" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "before" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "order" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
-    ],
-    "previews": [],
-    "renamed": { "note": null }
-  },
-  {
-    "method": "GET",
-    "url": "/enterprises/{enterprise}/settings/billing/actions",
-    "documentationUrl": "https://docs.github.com/rest/reference/billing#get-github-actions-billing-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
     "url": "/orgs/{org}/settings/billing/actions",
     "documentationUrl": "https://docs.github.com/rest/reference/billing#get-github-actions-billing-for-an-organization",
     "parameters": [
@@ -3237,16 +2895,6 @@
   },
   {
     "method": "GET",
-    "url": "/enterprises/{enterprise}/settings/billing/packages",
-    "documentationUrl": "https://docs.github.com/rest/reference/billing#get-github-packages-billing-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
     "url": "/orgs/{org}/settings/billing/packages",
     "documentationUrl": "https://docs.github.com/rest/reference/billing#get-github-packages-billing-for-an-organization",
     "parameters": [
@@ -3261,16 +2909,6 @@
     "documentationUrl": "https://docs.github.com/rest/reference/billing#get-github-packages-billing-for-a-user",
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/enterprises/{enterprise}/settings/billing/shared-storage",
-    "documentationUrl": "https://docs.github.com/rest/reference/billing#get-shared-storage-billing-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
     ],
     "previews": [],
     "renamed": null
@@ -3969,6 +3607,28 @@
     "renamed": null
   },
   {
+    "method": "PUT",
+    "url": "/organizations/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}",
+    "documentationUrl": "https://docs.github.com/rest/reference/codespaces#add-selected-repository-to-an-organization-secret",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "PATH",
+        "name": "secret_name"
+      },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "PATH",
+        "name": "repository_id"
+      }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
     "method": "GET",
     "url": "/user/codespaces/{codespace_name}/machines",
     "documentationUrl": "https://docs.github.com/rest/reference/codespaces#list-machine-types-for-a-codespace",
@@ -4051,6 +3711,36 @@
         "deprecated": null,
         "in": "BODY",
         "name": "pull_request.repository_id"
+      }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
+    "method": "PUT",
+    "url": "/organizations/{org}/codespaces/secrets/{secret_name}",
+    "documentationUrl": "https://docs.github.com/rest/reference/codespaces#create-or-update-an-organization-secret",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "PATH",
+        "name": "secret_name"
+      },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "BODY",
+        "name": "encrypted_value"
+      },
+      { "alias": null, "deprecated": null, "in": "BODY", "name": "key_id" },
+      { "alias": null, "deprecated": null, "in": "BODY", "name": "visibility" },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "BODY",
+        "name": "selected_repository_ids"
       }
     ],
     "previews": [],
@@ -4249,6 +3939,17 @@
   },
   {
     "method": "DELETE",
+    "url": "/organizations/{org}/codespaces/secrets/{secret_name}",
+    "documentationUrl": "https://docs.github.com/rest/reference/codespaces#delete-an-organization-secret",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
+    "method": "DELETE",
     "url": "/repos/{owner}/{repo}/codespaces/secrets/{secret_name}",
     "documentationUrl": "https://docs.github.com/rest/reference/codespaces#delete-a-repository-secret",
     "parameters": [
@@ -4311,6 +4012,27 @@
         "in": "PATH",
         "name": "codespace_name"
       }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
+    "method": "GET",
+    "url": "/organizations/{org}/codespaces/secrets/public-key",
+    "documentationUrl": "https://docs.github.com/rest/reference/codespaces#get-an-organization-public-key",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
+    "method": "GET",
+    "url": "/organizations/{org}/codespaces/secrets/{secret_name}",
+    "documentationUrl": "https://docs.github.com/rest/reference/codespaces#get-an-organization-secret",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
     "previews": [],
     "renamed": null
@@ -4414,6 +4136,18 @@
   },
   {
     "method": "GET",
+    "url": "/organizations/{org}/codespaces/secrets",
+    "documentationUrl": "https://docs.github.com/rest/reference/codespaces#list-organization-secrets",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
+    "method": "GET",
     "url": "/repos/{owner}/{repo}/codespaces/secrets",
     "documentationUrl": "https://docs.github.com/rest/reference/codespaces#list-repository-secrets",
     "parameters": [
@@ -4442,6 +4176,24 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
+    "method": "GET",
+    "url": "/organizations/{org}/codespaces/secrets/{secret_name}/repositories",
+    "documentationUrl": "https://docs.github.com/rest/reference/codespaces#list-selected-repositories-for-an-organization-secret",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "PATH",
+        "name": "secret_name"
+      },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
     "previews": [],
     "renamed": null
@@ -4481,6 +4233,28 @@
     "renamed": null
   },
   {
+    "method": "DELETE",
+    "url": "/organizations/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}",
+    "documentationUrl": "https://docs.github.com/rest/reference/codespaces#remove-selected-repository-from-an-organization-secret",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "PATH",
+        "name": "secret_name"
+      },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "PATH",
+        "name": "repository_id"
+      }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
     "method": "GET",
     "url": "/repos/{owner}/{repo}/codespaces/machines",
     "documentationUrl": "https://docs.github.com/rest/reference/codespaces#list-available-machine-types-for-a-repository",
@@ -4498,6 +4272,28 @@
     "url": "/user/codespaces/secrets/{secret_name}/repositories",
     "documentationUrl": "https://docs.github.com/rest/reference/codespaces#set-selected-repositories-for-a-user-secret",
     "parameters": [
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "PATH",
+        "name": "secret_name"
+      },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "BODY",
+        "name": "selected_repository_ids"
+      }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
+    "method": "PUT",
+    "url": "/organizations/{org}/codespaces/secrets/{secret_name}/repositories",
+    "documentationUrl": "https://docs.github.com/rest/reference/codespaces#set-selected-repositories-for-an-organization-secret",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       {
         "alias": null,
         "deprecated": null,
@@ -4690,6 +4486,23 @@
   },
   {
     "method": "GET",
+    "url": "/repos/{owner}/{repo}/dependabot/alerts/{alert_number}",
+    "documentationUrl": "https://docs.github.com/rest/reference/dependabot#get-a-dependabot-alert",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "PATH",
+        "name": "alert_number"
+      }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
+    "method": "GET",
     "url": "/orgs/{org}/dependabot/secrets/public-key",
     "documentationUrl": "https://docs.github.com/rest/reference/dependabot#get-an-organization-public-key",
     "parameters": [
@@ -4728,6 +4541,27 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
+    "method": "GET",
+    "url": "/repos/{owner}/{repo}/dependabot/alerts",
+    "documentationUrl": "https://docs.github.com/rest/reference/dependabot#list-dependabot-alerts-for-a-repository",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "state" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "severity" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "ecosystem" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "package" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "manifest" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "scope" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "sort" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "direction" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
+      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
     "previews": [],
     "renamed": null
@@ -4814,6 +4648,36 @@
         "deprecated": null,
         "in": "BODY",
         "name": "selected_repository_ids"
+      }
+    ],
+    "previews": [],
+    "renamed": null
+  },
+  {
+    "method": "PATCH",
+    "url": "/repos/{owner}/{repo}/dependabot/alerts/{alert_number}",
+    "documentationUrl": "https://docs.github.com/rest/reference/dependabot#update-a-dependabot-alert",
+    "parameters": [
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
+      { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "PATH",
+        "name": "alert_number"
+      },
+      { "alias": null, "deprecated": null, "in": "BODY", "name": "state" },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "BODY",
+        "name": "dismissed_reason"
+      },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "BODY",
+        "name": "dismissed_comment"
       }
     ],
     "previews": [],
@@ -4988,156 +4852,6 @@
     "renamed": null
   },
   {
-    "method": "PUT",
-    "url": "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#add-organization-access-to-a-self-hosted-runner-group-in-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org_id" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
-    "url": "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#add-a-self-hosted-runner-to-a-group-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "POST",
-    "url": "/enterprises/{enterprise}/actions/runners/registration-token",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#create-a-registration-token-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "POST",
-    "url": "/enterprises/{enterprise}/actions/runners/remove-token",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#create-a-remove-token-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "POST",
-    "url": "/enterprises/{enterprise}/actions/runner-groups",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#create-self-hosted-runner-group-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "name" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "visibility" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "selected_organization_ids"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "runners" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "allows_public_repositories"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "restricted_to_workflows"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "selected_workflows"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "DELETE",
-    "url": "/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#delete-a-scim-group-from-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_group_id"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "DELETE",
-    "url": "/enterprises/{enterprise}/actions/runners/{runner_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#delete-self-hosted-runner-from-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "DELETE",
-    "url": "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#delete-a-self-hosted-runner-group-from-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "DELETE",
-    "url": "/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#delete-a-scim-user-from-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_user_id"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
     "method": "DELETE",
     "url": "/enterprises/{enterprise}/actions/permissions/organizations/{org_id}",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#disable-a-selected-organization-for-github-actions-in-an-enterprise",
@@ -5171,114 +4885,10 @@
   },
   {
     "method": "GET",
-    "url": "/enterprises/{enterprise}/audit-log",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#get-the-audit-log-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "phrase" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "include" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "after" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "before" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "order" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/enterprises/{enterprise}/consumed-licenses",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#list-enterprise-consumed-licenses",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
     "url": "/enterprises/{enterprise}/actions/permissions",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#get-github-actions-permissions-for-an-enterprise",
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/enterprises/{enterprise}/license-sync-status",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#get-a-license-sync-status",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#get-scim-provisioning-information-for-an-enterprise-group",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_group_id"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "QUERY",
-        "name": "excludedAttributes"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#get-scim-provisioning-information-for-an-enterprise-user",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_user_id"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/enterprises/{enterprise}/actions/runners/{runner_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#get-a-self-hosted-runner-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#get-a-self-hosted-runner-group-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      }
     ],
     "previews": [],
     "renamed": null
@@ -5318,205 +4928,12 @@
   },
   {
     "method": "GET",
-    "url": "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#list-organization-access-to-a-self-hosted-runner-group-in-a-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/scim/v2/enterprises/{enterprise}/Groups",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#list-provisioned-scim-groups-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "QUERY",
-        "name": "startIndex"
-      },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "count" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "filter" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "QUERY",
-        "name": "excludedAttributes"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/scim/v2/enterprises/{enterprise}/Users",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#list-scim-provisioned-identities-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "QUERY",
-        "name": "startIndex"
-      },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "count" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "filter" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/enterprises/{enterprise}/actions/runners/downloads",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#list-runner-applications-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
     "url": "/enterprises/{enterprise}/actions/permissions/organizations",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#list-selected-organizations-enabled-for-github-actions-in-an-enterprise",
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/enterprises/{enterprise}/actions/runner-groups",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#list-self-hosted-runner-groups-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "QUERY",
-        "name": "visible_to_organization"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/enterprises/{enterprise}/actions/runners",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#list-self-hosted-runners-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#list-self-hosted-runners-in-a-group-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "POST",
-    "url": "/scim/v2/enterprises/{enterprise}/Groups",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#provision-a-scim-enterprise-group-and-invite-users",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "schemas" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "displayName"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "members" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "members[].value"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "POST",
-    "url": "/scim/v2/enterprises/{enterprise}/Users",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#provision-and-invite-a-scim-enterprise-user",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "schemas" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "userName" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "name" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "name.givenName"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "name.familyName"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "emails" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].value"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].type"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].primary"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "groups" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "groups[].value"
-      }
     ],
     "previews": [],
     "renamed": null
@@ -5540,40 +4957,6 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "name" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "DELETE",
-    "url": "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#remove-organization-access-to-a-self-hosted-runner-group-in-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org_id" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "DELETE",
-    "url": "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#remove-a-self-hosted-runner-from-a-group-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
     "previews": [],
     "renamed": null
@@ -5642,115 +5025,6 @@
   },
   {
     "method": "PUT",
-    "url": "/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#set-scim-information-for-a-provisioned-enterprise-group",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "schemas" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "displayName"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "members" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "members[].value"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
-    "url": "/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#set-scim-information-for-a-provisioned-enterprise-user",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_user_id"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "schemas" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "userName" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "name" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "name.givenName"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "name.familyName"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "emails" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].value"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].type"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].primary"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "groups" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "groups[].value"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
-    "url": "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#set-organization-access-to-a-self-hosted-runner-group-in-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "selected_organization_ids"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
     "url": "/enterprises/{enterprise}/actions/permissions/organizations",
     "documentationUrl": "https://docs.github.com/rest/reference/actions#set-selected-organizations-enabled-for-github-actions-in-an-enterprise",
     "parameters": [
@@ -5760,113 +5034,6 @@
         "deprecated": null,
         "in": "BODY",
         "name": "selected_organization_ids"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
-    "url": "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#set-self-hosted-runners-in-a-group-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "runners" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PATCH",
-    "url": "/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#update-an-attribute-for-a-scim-enterprise-group",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "schemas" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "Operations" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "Operations[].op"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "Operations[].path"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "Operations[].value"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PATCH",
-    "url": "/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/enterprise-admin#update-an-attribute-for-a-scim-enterprise-user",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_user_id"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "schemas" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "Operations" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PATCH",
-    "url": "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/actions#update-a-self-hosted-runner-group-for-an-enterprise",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "runner_group_id"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "name" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "visibility" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "allows_public_repositories"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "restricted_to_workflows"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "selected_workflows"
       }
     ],
     "previews": [],
@@ -7730,32 +6897,6 @@
     "renamed": null
   },
   {
-    "method": "GET",
-    "url": "/orgs/{org}/actions/oidc/customization/sub",
-    "documentationUrl": "https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
-    "url": "/orgs/{org}/actions/oidc/customization/sub",
-    "documentationUrl": "https://docs.github.com/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "include_claim_keys"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
     "method": "PUT",
     "url": "/orgs/{org}/security-managers/teams/{team_slug}",
     "documentationUrl": "https://docs.github.com/rest/reference/orgs#add-a-security-manager-team",
@@ -7961,22 +7102,6 @@
     "documentationUrl": "https://docs.github.com/rest/reference/orgs#get-an-organization",
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/orgs/{org}/audit-log",
-    "documentationUrl": "https://docs.github.com/rest/reference/orgs#get-audit-log",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "phrase" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "include" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "after" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "before" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "order" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
     "previews": [],
     "renamed": null
@@ -8212,19 +7337,6 @@
   },
   {
     "method": "GET",
-    "url": "/orgs/{org}/credential-authorizations",
-    "documentationUrl": "https://docs.github.com/rest/reference/orgs#list-saml-sso-authorizations-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "login" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
     "url": "/orgs/{org}/security-managers",
     "documentationUrl": "https://docs.github.com/rest/reference/orgs#list-security-manager-teams",
     "parameters": [
@@ -8321,22 +7433,6 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "DELETE",
-    "url": "/orgs/{org}/credential-authorizations/{credential_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/orgs#remove-a-saml-sso-authorization-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "credential_id"
-      }
     ],
     "previews": [],
     "renamed": null
@@ -13902,216 +12998,6 @@
     "renamed": null
   },
   {
-    "method": "DELETE",
-    "url": "/scim/v2/organizations/{org}/Users/{scim_user_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/scim#delete-a-scim-user-from-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_user_id"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/scim/v2/organizations/{org}/Users/{scim_user_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/scim#get-scim-provisioning-information-for-a-user",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_user_id"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/scim/v2/organizations/{org}/Users",
-    "documentationUrl": "https://docs.github.com/rest/reference/scim#list-scim-provisioned-identities",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "QUERY",
-        "name": "startIndex"
-      },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "count" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "filter" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "POST",
-    "url": "/scim/v2/organizations/{org}/Users",
-    "documentationUrl": "https://docs.github.com/rest/reference/scim#provision-and-invite-a-scim-user",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "userName" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "displayName"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "name" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "name.givenName"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "name.familyName"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "name.formatted"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "emails" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].value"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].primary"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].type"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "schemas" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "externalId" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "groups" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "active" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PUT",
-    "url": "/scim/v2/organizations/{org}/Users/{scim_user_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/scim#set-scim-information-for-a-provisioned-user",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_user_id"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "schemas" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "displayName"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "externalId" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "groups" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "active" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "userName" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "name" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "name.givenName"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "name.familyName"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "name.formatted"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "emails" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].type"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].value"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "emails[].primary"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PATCH",
-    "url": "/scim/v2/organizations/{org}/Users/{scim_user_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/scim#update-an-attribute-for-a-scim-user",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "PATH",
-        "name": "scim_user_id"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "schemas" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "Operations" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "Operations[].op"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "Operations[].path"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "Operations[].value"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
     "method": "GET",
     "url": "/search/code",
     "documentationUrl": "https://docs.github.com/rest/reference/search#search-code",
@@ -14350,7 +13236,13 @@
         "name": "alert_number"
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "state" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "resolution" }
+      { "alias": null, "deprecated": null, "in": "BODY", "name": "resolution" },
+      {
+        "alias": null,
+        "deprecated": null,
+        "in": "BODY",
+        "name": "resolution_comment"
+      }
     ],
     "previews": [],
     "renamed": null
@@ -14586,84 +13478,6 @@
     "renamed": null
   },
   {
-    "method": "PATCH",
-    "url": "/orgs/{org}/teams/{team_slug}/team-sync/group-mappings",
-    "documentationUrl": "https://docs.github.com/rest/reference/teams#create-or-update-idp-group-connections",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "groups" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "groups[].group_id"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "groups[].group_name"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "groups[].group_description"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "PATCH",
-    "url": "/teams/{team_id}/team-sync/group-mappings",
-    "documentationUrl": "https://docs.github.com/rest/reference/teams#create-or-update-idp-group-connections-legacy",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "groups" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "groups[].group_id"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "groups[].group_name"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "groups[].group_description"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "groups[].id"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "groups[].name"
-      },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "BODY",
-        "name": "groups[].description"
-      },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "synced_at" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
     "method": "DELETE",
     "url": "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",
     "documentationUrl": "https://docs.github.com/rest/reference/teams#delete-a-discussion-comment",
@@ -14758,17 +13572,6 @@
     "documentationUrl": "https://docs.github.com/rest/reference/teams/#delete-a-team-legacy",
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/orgs/{org}/external-group/{group_id}",
-    "documentationUrl": "https://docs.github.com/rest/reference/teams#external-idp-group-info-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "group_id" }
     ],
     "previews": [],
     "renamed": null
@@ -14907,18 +13710,6 @@
     "renamed": null
   },
   {
-    "method": "PATCH",
-    "url": "/orgs/{org}/teams/{team_slug}/external-groups",
-    "documentationUrl": "https://docs.github.com/rest/reference/teams#link-external-idp-group-team-connection",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" },
-      { "alias": null, "deprecated": null, "in": "BODY", "name": "group_id" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
     "method": "GET",
     "url": "/orgs/{org}/teams",
     "documentationUrl": "https://docs.github.com/rest/reference/teams#list-teams",
@@ -15024,73 +13815,11 @@
   },
   {
     "method": "GET",
-    "url": "/orgs/{org}/external-groups",
-    "documentationUrl": "https://docs.github.com/rest/reference/teams#list-external-idp-groups-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
-      {
-        "alias": null,
-        "deprecated": null,
-        "in": "QUERY",
-        "name": "display_name"
-      }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
     "url": "/user/teams",
     "documentationUrl": "https://docs.github.com/rest/reference/teams#list-teams-for-the-authenticated-user",
     "parameters": [
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/teams/{team_id}/team-sync/group-mappings",
-    "documentationUrl": "https://docs.github.com/rest/reference/teams#list-idp-groups-for-a-team-legacy",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/orgs/{org}/team-sync/groups",
-    "documentationUrl": "https://docs.github.com/rest/reference/teams#list-idp-groups-for-an-organization",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
-      { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/orgs/{org}/teams/{team_slug}/team-sync/group-mappings",
-    "documentationUrl": "https://docs.github.com/rest/reference/teams#list-idp-groups-for-a-team",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "GET",
-    "url": "/orgs/{org}/teams/{team_slug}/external-groups",
-    "documentationUrl": "https://docs.github.com/rest/reference/teams#list-external-idp-group-team-connection",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" }
     ],
     "previews": [],
     "renamed": null
@@ -15275,17 +14004,6 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
-    ],
-    "previews": [],
-    "renamed": null
-  },
-  {
-    "method": "DELETE",
-    "url": "/orgs/{org}/teams/{team_slug}/external-groups",
-    "documentationUrl": "https://docs.github.com/rest/reference/teams#unlink-external-idp-group-team-connection",
-    "parameters": [
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
-      { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" }
     ],
     "previews": [],
     "renamed": null

--- a/src/generated/Endpoints.ts
+++ b/src/generated/Endpoints.ts
@@ -141,34 +141,6 @@ export interface Endpoints {
     "delete"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/actions#delete-a-self-hosted-runner-group-from-an-enterprise
-   */
-  "DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
-    "delete"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#remove-organization-access-to-a-self-hosted-runner-group-in-an-enterprise
-   */
-  "DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}",
-    "delete"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#remove-a-self-hosted-runner-from-a-group-for-an-enterprise
-   */
-  "DELETE /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
-    "delete"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#delete-self-hosted-runner-from-an-enterprise
-   */
-  "DELETE /enterprises/{enterprise}/actions/runners/{runner_id}": Operation<
-    "/enterprises/{enterprise}/actions/runners/{runner_id}",
-    "delete"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/actions#remove-all-custom-labels-from-a-self-hosted-runner-for-an-enterprise
    */
   "DELETE /enterprises/{enterprise}/actions/runners/{runner_id}/labels": Operation<
@@ -209,31 +181,24 @@ export interface Endpoints {
     "delete"
   >;
   /**
+   * @see https://docs.github.com/rest/reference/codespaces#delete-an-organization-secret
+   */
+  "DELETE /organizations/{org}/codespaces/secrets/{secret_name}": Operation<
+    "/organizations/{org}/codespaces/secrets/{secret_name}",
+    "delete"
+  >;
+  /**
+   * @see https://docs.github.com/rest/reference/codespaces#remove-selected-repository-from-an-organization-secret
+   */
+  "DELETE /organizations/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}": Operation<
+    "/organizations/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}",
+    "delete"
+  >;
+  /**
    * @see https://docs.github.com/rest/reference/actions#disable-a-selected-repository-for-github-actions-in-an-organization
    */
   "DELETE /orgs/{org}/actions/permissions/repositories/{repository_id}": Operation<
     "/orgs/{org}/actions/permissions/repositories/{repository_id}",
-    "delete"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#delete-a-self-hosted-runner-group-from-an-organization
-   */
-  "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}": Operation<
-    "/orgs/{org}/actions/runner-groups/{runner_group_id}",
-    "delete"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#remove-repository-access-to-a-self-hosted-runner-group-in-an-organization
-   */
-  "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}": Operation<
-    "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}",
-    "delete"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#remove-a-self-hosted-runner-from-a-group-for-an-organization
-   */
-  "DELETE /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}": Operation<
-    "/orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
     "delete"
   >;
   /**
@@ -276,13 +241,6 @@ export interface Endpoints {
    */
   "DELETE /orgs/{org}/blocks/{username}": Operation<
     "/orgs/{org}/blocks/{username}",
-    "delete"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/orgs#remove-a-saml-sso-authorization-for-an-organization
-   */
-  "DELETE /orgs/{org}/credential-authorizations/{credential_id}": Operation<
-    "/orgs/{org}/credential-authorizations/{credential_id}",
     "delete"
   >;
   /**
@@ -430,13 +388,6 @@ export interface Endpoints {
    */
   "DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}": Operation<
     "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}",
-    "delete"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/teams#unlink-external-idp-group-team-connection
-   */
-  "DELETE /orgs/{org}/teams/{team_slug}/external-groups": Operation<
-    "/orgs/{org}/teams/{team_slug}/external-groups",
     "delete"
   >;
   /**
@@ -906,27 +857,6 @@ export interface Endpoints {
     "delete"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#delete-a-scim-group-from-an-enterprise
-   */
-  "DELETE /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}": Operation<
-    "/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}",
-    "delete"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#delete-a-scim-user-from-an-enterprise
-   */
-  "DELETE /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}": Operation<
-    "/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}",
-    "delete"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/scim#delete-a-scim-user-from-an-organization
-   */
-  "DELETE /scim/v2/organizations/{org}/Users/{scim_user_id}": Operation<
-    "/scim/v2/organizations/{org}/Users/{scim_user_id}",
-    "delete"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/teams/#delete-a-team-legacy
    */
   "DELETE /teams/{team_id}": Operation<"/teams/{team_id}", "delete">;
@@ -1192,66 +1122,10 @@ export interface Endpoints {
     "get"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/actions#list-self-hosted-runner-groups-for-an-enterprise
-   */
-  "GET /enterprises/{enterprise}/actions/runner-groups": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#get-a-self-hosted-runner-group-for-an-enterprise
-   */
-  "GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#list-organization-access-to-a-self-hosted-runner-group-in-a-enterprise
-   */
-  "GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#list-self-hosted-runners-in-a-group-for-an-enterprise
-   */
-  "GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#list-self-hosted-runners-for-an-enterprise
-   */
-  "GET /enterprises/{enterprise}/actions/runners": Operation<
-    "/enterprises/{enterprise}/actions/runners",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#list-runner-applications-for-an-enterprise
-   */
-  "GET /enterprises/{enterprise}/actions/runners/downloads": Operation<
-    "/enterprises/{enterprise}/actions/runners/downloads",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#get-a-self-hosted-runner-for-an-enterprise
-   */
-  "GET /enterprises/{enterprise}/actions/runners/{runner_id}": Operation<
-    "/enterprises/{enterprise}/actions/runners/{runner_id}",
-    "get"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/actions#list-labels-for-a-self-hosted-runner-for-an-enterprise
    */
   "GET /enterprises/{enterprise}/actions/runners/{runner_id}/labels": Operation<
     "/enterprises/{enterprise}/actions/runners/{runner_id}/labels",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#get-the-audit-log-for-an-enterprise
-   */
-  "GET /enterprises/{enterprise}/audit-log": Operation<
-    "/enterprises/{enterprise}/audit-log",
     "get"
   >;
   /**
@@ -1262,20 +1136,6 @@ export interface Endpoints {
     "get"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#list-enterprise-consumed-licenses
-   */
-  "GET /enterprises/{enterprise}/consumed-licenses": Operation<
-    "/enterprises/{enterprise}/consumed-licenses",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#get-a-license-sync-status
-   */
-  "GET /enterprises/{enterprise}/license-sync-status": Operation<
-    "/enterprises/{enterprise}/license-sync-status",
-    "get"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/secret-scanning#list-secret-scanning-alerts-for-an-enterprise
    */
   "GET /enterprises/{enterprise}/secret-scanning/alerts": Operation<
@@ -1283,31 +1143,10 @@ export interface Endpoints {
     "get"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/billing#get-github-actions-billing-for-an-enterprise
-   */
-  "GET /enterprises/{enterprise}/settings/billing/actions": Operation<
-    "/enterprises/{enterprise}/settings/billing/actions",
-    "get"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/billing#export-advanced-security-active-committers-data-for-enterprise
    */
   "GET /enterprises/{enterprise}/settings/billing/advanced-security": Operation<
     "/enterprises/{enterprise}/settings/billing/advanced-security",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/billing#get-github-packages-billing-for-an-enterprise
-   */
-  "GET /enterprises/{enterprise}/settings/billing/packages": Operation<
-    "/enterprises/{enterprise}/settings/billing/packages",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/billing#get-shared-storage-billing-for-an-enterprise
-   */
-  "GET /enterprises/{enterprise}/settings/billing/shared-storage": Operation<
-    "/enterprises/{enterprise}/settings/billing/shared-storage",
     "get"
   >;
   /**
@@ -1481,6 +1320,34 @@ export interface Endpoints {
     "get"
   >;
   /**
+   * @see https://docs.github.com/rest/reference/codespaces#list-organization-secrets
+   */
+  "GET /organizations/{org}/codespaces/secrets": Operation<
+    "/organizations/{org}/codespaces/secrets",
+    "get"
+  >;
+  /**
+   * @see https://docs.github.com/rest/reference/codespaces#get-an-organization-public-key
+   */
+  "GET /organizations/{org}/codespaces/secrets/public-key": Operation<
+    "/organizations/{org}/codespaces/secrets/public-key",
+    "get"
+  >;
+  /**
+   * @see https://docs.github.com/rest/reference/codespaces#get-an-organization-secret
+   */
+  "GET /organizations/{org}/codespaces/secrets/{secret_name}": Operation<
+    "/organizations/{org}/codespaces/secrets/{secret_name}",
+    "get"
+  >;
+  /**
+   * @see https://docs.github.com/rest/reference/codespaces#list-selected-repositories-for-an-organization-secret
+   */
+  "GET /organizations/{org}/codespaces/secrets/{secret_name}/repositories": Operation<
+    "/organizations/{org}/codespaces/secrets/{secret_name}/repositories",
+    "get"
+  >;
+  /**
    * @see https://docs.github.com/rest/reference/codespaces#list-in-organization
    * @deprecated "org_id" is now "org"
    */
@@ -1501,13 +1368,6 @@ export interface Endpoints {
    */
   "GET /orgs/{org}/actions/cache/usage-by-repository": Operation<
     "/orgs/{org}/actions/cache/usage-by-repository",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/actions/oidc#get-the-customization-template-for-an-oidc-subject-claim-for-an-organization
-   */
-  "GET /orgs/{org}/actions/oidc/customization/sub": Operation<
-    "/orgs/{org}/actions/oidc/customization/sub",
     "get"
   >;
   /**
@@ -1536,34 +1396,6 @@ export interface Endpoints {
    */
   "GET /orgs/{org}/actions/permissions/workflow": Operation<
     "/orgs/{org}/actions/permissions/workflow",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#list-self-hosted-runner-groups-for-an-organization
-   */
-  "GET /orgs/{org}/actions/runner-groups": Operation<
-    "/orgs/{org}/actions/runner-groups",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#get-a-self-hosted-runner-group-for-an-organization
-   */
-  "GET /orgs/{org}/actions/runner-groups/{runner_group_id}": Operation<
-    "/orgs/{org}/actions/runner-groups/{runner_group_id}",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#list-repository-access-to-a-self-hosted-runner-group-in-an-organization
-   */
-  "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories": Operation<
-    "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#list-self-hosted-runners-in-a-group-for-an-organization
-   */
-  "GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners": Operation<
-    "/orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
     "get"
   >;
   /**
@@ -1623,10 +1455,6 @@ export interface Endpoints {
     "get"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/orgs#get-audit-log
-   */
-  "GET /orgs/{org}/audit-log": Operation<"/orgs/{org}/audit-log", "get">;
-  /**
    * @see https://docs.github.com/rest/reference/orgs#list-users-blocked-by-an-organization
    */
   "GET /orgs/{org}/blocks": Operation<"/orgs/{org}/blocks", "get">;
@@ -1648,13 +1476,6 @@ export interface Endpoints {
    * @see https://docs.github.com/rest/reference/codespaces#list-in-organization
    */
   "GET /orgs/{org}/codespaces": Operation<"/orgs/{org}/codespaces", "get">;
-  /**
-   * @see https://docs.github.com/rest/reference/orgs#list-saml-sso-authorizations-for-an-organization
-   */
-  "GET /orgs/{org}/credential-authorizations": Operation<
-    "/orgs/{org}/credential-authorizations",
-    "get"
-  >;
   /**
    * @see https://docs.github.com/rest/reference/dependabot#list-organization-secrets
    */
@@ -1687,20 +1508,6 @@ export interface Endpoints {
    * @see https://docs.github.com/rest/reference/activity#list-public-organization-events
    */
   "GET /orgs/{org}/events": Operation<"/orgs/{org}/events", "get">;
-  /**
-   * @see https://docs.github.com/rest/reference/teams#external-idp-group-info-for-an-organization
-   */
-  "GET /orgs/{org}/external-group/{group_id}": Operation<
-    "/orgs/{org}/external-group/{group_id}",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/teams#list-external-idp-groups-for-an-organization
-   */
-  "GET /orgs/{org}/external-groups": Operation<
-    "/orgs/{org}/external-groups",
-    "get"
-  >;
   /**
    * @see https://docs.github.com/rest/reference/orgs#list-failed-organization-invitations
    */
@@ -1920,13 +1727,6 @@ export interface Endpoints {
     "get"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/teams#list-idp-groups-for-an-organization
-   */
-  "GET /orgs/{org}/team-sync/groups": Operation<
-    "/orgs/{org}/team-sync/groups",
-    "get"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/teams#list-teams
    */
   "GET /orgs/{org}/teams": Operation<"/orgs/{org}/teams", "get">;
@@ -1980,13 +1780,6 @@ export interface Endpoints {
     "get"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/teams#list-external-idp-group-team-connection
-   */
-  "GET /orgs/{org}/teams/{team_slug}/external-groups": Operation<
-    "/orgs/{org}/teams/{team_slug}/external-groups",
-    "get"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/teams#list-pending-team-invitations
    */
   "GET /orgs/{org}/teams/{team_slug}/invitations": Operation<
@@ -2033,13 +1826,6 @@ export interface Endpoints {
    */
   "GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}": Operation<
     "/orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/teams#list-idp-groups-for-a-team
-   */
-  "GET /orgs/{org}/teams/{team_slug}/team-sync/group-mappings": Operation<
-    "/orgs/{org}/teams/{team_slug}/team-sync/group-mappings",
     "get"
   >;
   /**
@@ -2150,13 +1936,6 @@ export interface Endpoints {
    */
   "GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs": Operation<
     "/repos/{owner}/{repo}/actions/jobs/{job_id}/logs",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/actions/oidc#get-the-opt-out-flag-of-an-oidc-subject-claim-customization-for-a-repository
-   */
-  "GET /repos/{owner}/{repo}/actions/oidc/customization/sub": Operation<
-    "/repos/{owner}/{repo}/actions/oidc/customization/sub",
     "get"
   >;
   /**
@@ -2739,6 +2518,20 @@ export interface Endpoints {
    */
   "GET /repos/{owner}/{repo}/contributors": Operation<
     "/repos/{owner}/{repo}/contributors",
+    "get"
+  >;
+  /**
+   * @see https://docs.github.com/rest/reference/dependabot#list-dependabot-alerts-for-a-repository
+   */
+  "GET /repos/{owner}/{repo}/dependabot/alerts": Operation<
+    "/repos/{owner}/{repo}/dependabot/alerts",
+    "get"
+  >;
+  /**
+   * @see https://docs.github.com/rest/reference/dependabot#get-a-dependabot-alert
+   */
+  "GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}": Operation<
+    "/repos/{owner}/{repo}/dependabot/alerts/{alert_number}",
     "get"
   >;
   /**
@@ -3488,48 +3281,6 @@ export interface Endpoints {
     "get"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#list-provisioned-scim-groups-for-an-enterprise
-   */
-  "GET /scim/v2/enterprises/{enterprise}/Groups": Operation<
-    "/scim/v2/enterprises/{enterprise}/Groups",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#get-scim-provisioning-information-for-an-enterprise-group
-   */
-  "GET /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}": Operation<
-    "/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#list-scim-provisioned-identities-for-an-enterprise
-   */
-  "GET /scim/v2/enterprises/{enterprise}/Users": Operation<
-    "/scim/v2/enterprises/{enterprise}/Users",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#get-scim-provisioning-information-for-an-enterprise-user
-   */
-  "GET /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}": Operation<
-    "/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/scim#list-scim-provisioned-identities
-   */
-  "GET /scim/v2/organizations/{org}/Users": Operation<
-    "/scim/v2/organizations/{org}/Users",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/scim#get-scim-provisioning-information-for-a-user
-   */
-  "GET /scim/v2/organizations/{org}/Users/{scim_user_id}": Operation<
-    "/scim/v2/organizations/{org}/Users/{scim_user_id}",
-    "get"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/search#search-code
    */
   "GET /search/code": Operation<"/search/code", "get">;
@@ -3651,13 +3402,6 @@ export interface Endpoints {
    */
   "GET /teams/{team_id}/repos/{owner}/{repo}": Operation<
     "/teams/{team_id}/repos/{owner}/{repo}",
-    "get"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/teams#list-idp-groups-for-a-team-legacy
-   */
-  "GET /teams/{team_id}/team-sync/group-mappings": Operation<
-    "/teams/{team_id}/team-sync/group-mappings",
     "get"
   >;
   /**
@@ -4098,13 +3842,6 @@ export interface Endpoints {
     "patch"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/actions#update-a-self-hosted-runner-group-for-an-enterprise
-   */
-  "PATCH /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}",
-    "patch"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/gists/#update-a-gist
    */
   "PATCH /gists/{gist_id}": Operation<"/gists/{gist_id}", "patch">;
@@ -4126,13 +3863,6 @@ export interface Endpoints {
    * @see https://docs.github.com/rest/reference/orgs/#update-an-organization
    */
   "PATCH /orgs/{org}": Operation<"/orgs/{org}", "patch">;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#update-a-self-hosted-runner-group-for-an-organization
-   */
-  "PATCH /orgs/{org}/actions/runner-groups/{runner_group_id}": Operation<
-    "/orgs/{org}/actions/runner-groups/{runner_group_id}",
-    "patch"
-  >;
   /**
    * @see https://docs.github.com/rest/reference/orgs#update-a-custom-role
    */
@@ -4173,20 +3903,6 @@ export interface Endpoints {
    */
   "PATCH /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}": Operation<
     "/orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}",
-    "patch"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/teams#link-external-idp-group-team-connection
-   */
-  "PATCH /orgs/{org}/teams/{team_slug}/external-groups": Operation<
-    "/orgs/{org}/teams/{team_slug}/external-groups",
-    "patch"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/teams#create-or-update-idp-group-connections
-   */
-  "PATCH /orgs/{org}/teams/{team_slug}/team-sync/group-mappings": Operation<
-    "/orgs/{org}/teams/{team_slug}/team-sync/group-mappings",
     "patch"
   >;
   /**
@@ -4251,6 +3967,13 @@ export interface Endpoints {
    */
   "PATCH /repos/{owner}/{repo}/comments/{comment_id}": Operation<
     "/repos/{owner}/{repo}/comments/{comment_id}",
+    "patch"
+  >;
+  /**
+   * @see https://docs.github.com/rest/reference/dependabot#update-a-dependabot-alert
+   */
+  "PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}": Operation<
+    "/repos/{owner}/{repo}/dependabot/alerts/{alert_number}",
     "patch"
   >;
   /**
@@ -4366,27 +4089,6 @@ export interface Endpoints {
     "patch"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#update-an-attribute-for-a-scim-enterprise-group
-   */
-  "PATCH /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}": Operation<
-    "/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}",
-    "patch"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#update-an-attribute-for-a-scim-enterprise-user
-   */
-  "PATCH /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}": Operation<
-    "/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}",
-    "patch"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/scim#update-an-attribute-for-a-scim-user
-   */
-  "PATCH /scim/v2/organizations/{org}/Users/{scim_user_id}": Operation<
-    "/scim/v2/organizations/{org}/Users/{scim_user_id}",
-    "patch"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/teams/#update-a-team-legacy
    */
   "PATCH /teams/{team_id}": Operation<"/teams/{team_id}", "patch">;
@@ -4402,13 +4104,6 @@ export interface Endpoints {
    */
   "PATCH /teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}": Operation<
     "/teams/{team_id}/discussions/{discussion_number}/comments/{comment_number}",
-    "patch"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/teams#create-or-update-idp-group-connections-legacy
-   */
-  "PATCH /teams/{team_id}/team-sync/group-mappings": Operation<
-    "/teams/{team_id}/team-sync/group-mappings",
     "patch"
   >;
   /**
@@ -4476,27 +4171,6 @@ export interface Endpoints {
     "post"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/actions#create-self-hosted-runner-group-for-an-enterprise
-   */
-  "POST /enterprises/{enterprise}/actions/runner-groups": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups",
-    "post"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#create-a-registration-token-for-an-enterprise
-   */
-  "POST /enterprises/{enterprise}/actions/runners/registration-token": Operation<
-    "/enterprises/{enterprise}/actions/runners/registration-token",
-    "post"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#create-a-remove-token-for-an-enterprise
-   */
-  "POST /enterprises/{enterprise}/actions/runners/remove-token": Operation<
-    "/enterprises/{enterprise}/actions/runners/remove-token",
-    "post"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/actions#add-custom-labels-to-a-self-hosted-runner-for-an-enterprise
    */
   "POST /enterprises/{enterprise}/actions/runners/{runner_id}/labels": Operation<
@@ -4526,13 +4200,6 @@ export interface Endpoints {
    * @see https://docs.github.com/rest/reference/markdown#render-a-markdown-document-in-raw-mode
    */
   "POST /markdown/raw": Operation<"/markdown/raw", "post">;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#create-a-self-hosted-runner-group-for-an-organization
-   */
-  "POST /orgs/{org}/actions/runner-groups": Operation<
-    "/orgs/{org}/actions/runner-groups",
-    "post"
-  >;
   /**
    * @see https://docs.github.com/rest/reference/actions#create-a-registration-token-for-an-organization
    */
@@ -5181,27 +4848,6 @@ export interface Endpoints {
     "post"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#provision-a-scim-enterprise-group-and-invite-users
-   */
-  "POST /scim/v2/enterprises/{enterprise}/Groups": Operation<
-    "/scim/v2/enterprises/{enterprise}/Groups",
-    "post"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#provision-and-invite-a-scim-enterprise-user
-   */
-  "POST /scim/v2/enterprises/{enterprise}/Users": Operation<
-    "/scim/v2/enterprises/{enterprise}/Users",
-    "post"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/scim#provision-and-invite-a-scim-user
-   */
-  "POST /scim/v2/organizations/{org}/Users": Operation<
-    "/scim/v2/organizations/{org}/Users",
-    "post"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/teams#create-a-discussion-legacy
    */
   "POST /teams/{team_id}/discussions": Operation<
@@ -5325,13 +4971,6 @@ export interface Endpoints {
     "put"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/actions/oidc#set-actions-oidc-custom-issuer-policy-for-enterprise
-   */
-  "PUT /enterprises/{enterprise}/actions/oidc/customization/issuer": Operation<
-    "/enterprises/{enterprise}/actions/oidc/customization/issuer",
-    "put"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/actions#set-github-actions-permissions-for-an-enterprise
    */
   "PUT /enterprises/{enterprise}/actions/permissions": Operation<
@@ -5367,34 +5006,6 @@ export interface Endpoints {
     "put"
   >;
   /**
-   * @see https://docs.github.com/rest/reference/actions#set-organization-access-to-a-self-hosted-runner-group-in-an-enterprise
-   */
-  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations",
-    "put"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#add-organization-access-to-a-self-hosted-runner-group-in-an-enterprise
-   */
-  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations/{org_id}",
-    "put"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#set-self-hosted-runners-in-a-group-for-an-enterprise
-   */
-  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners",
-    "put"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#add-a-self-hosted-runner-to-a-group-for-an-enterprise
-   */
-  "PUT /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}": Operation<
-    "/enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
-    "put"
-  >;
-  /**
    * @see https://docs.github.com/rest/reference/actions#set-custom-labels-for-a-self-hosted-runner-for-an-enterprise
    */
   "PUT /enterprises/{enterprise}/actions/runners/{runner_id}/labels": Operation<
@@ -5417,10 +5028,24 @@ export interface Endpoints {
     "put"
   >;
   /**
-   * @see https://docs.github.com/rest/actions/oidc#set-the-customization-template-for-an-oidc-subject-claim-for-an-organization
+   * @see https://docs.github.com/rest/reference/codespaces#create-or-update-an-organization-secret
    */
-  "PUT /orgs/{org}/actions/oidc/customization/sub": Operation<
-    "/orgs/{org}/actions/oidc/customization/sub",
+  "PUT /organizations/{org}/codespaces/secrets/{secret_name}": Operation<
+    "/organizations/{org}/codespaces/secrets/{secret_name}",
+    "put"
+  >;
+  /**
+   * @see https://docs.github.com/rest/reference/codespaces#set-selected-repositories-for-an-organization-secret
+   */
+  "PUT /organizations/{org}/codespaces/secrets/{secret_name}/repositories": Operation<
+    "/organizations/{org}/codespaces/secrets/{secret_name}/repositories",
+    "put"
+  >;
+  /**
+   * @see https://docs.github.com/rest/reference/codespaces#add-selected-repository-to-an-organization-secret
+   */
+  "PUT /organizations/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}": Operation<
+    "/organizations/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}",
     "put"
   >;
   /**
@@ -5456,34 +5081,6 @@ export interface Endpoints {
    */
   "PUT /orgs/{org}/actions/permissions/workflow": Operation<
     "/orgs/{org}/actions/permissions/workflow",
-    "put"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#set-repository-access-to-a-self-hosted-runner-group-in-an-organization
-   */
-  "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories": Operation<
-    "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories",
-    "put"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#add-repository-acess-to-a-self-hosted-runner-group-in-an-organization
-   */
-  "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}": Operation<
-    "/orgs/{org}/actions/runner-groups/{runner_group_id}/repositories/{repository_id}",
-    "put"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#set-self-hosted-runners-in-a-group-for-an-organization
-   */
-  "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners": Operation<
-    "/orgs/{org}/actions/runner-groups/{runner_group_id}/runners",
-    "put"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/actions#add-a-self-hosted-runner-to-a-group-for-an-organization
-   */
-  "PUT /orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}": Operation<
-    "/orgs/{org}/actions/runner-groups/{runner_group_id}/runners/{runner_id}",
     "put"
   >;
   /**
@@ -5603,13 +5200,6 @@ export interface Endpoints {
    */
   "PUT /projects/{project_id}/collaborators/{username}": Operation<
     "/projects/{project_id}/collaborators/{username}",
-    "put"
-  >;
-  /**
-   * @see https://docs.github.com/rest/actions/oidc#set-the-opt-out-flag-of-an-oidc-subject-claim-customization-for-a-repository
-   */
-  "PUT /repos/{owner}/{repo}/actions/oidc/customization/sub": Operation<
-    "/repos/{owner}/{repo}/actions/oidc/customization/sub",
     "put"
   >;
   /**
@@ -5855,27 +5445,6 @@ export interface Endpoints {
    */
   "PUT /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}": Operation<
     "/repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}",
-    "put"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#set-scim-information-for-a-provisioned-enterprise-group
-   */
-  "PUT /scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}": Operation<
-    "/scim/v2/enterprises/{enterprise}/Groups/{scim_group_id}",
-    "put"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/enterprise-admin#set-scim-information-for-a-provisioned-enterprise-user
-   */
-  "PUT /scim/v2/enterprises/{enterprise}/Users/{scim_user_id}": Operation<
-    "/scim/v2/enterprises/{enterprise}/Users/{scim_user_id}",
-    "put"
-  >;
-  /**
-   * @see https://docs.github.com/rest/reference/scim#set-scim-information-for-a-provisioned-user
-   */
-  "PUT /scim/v2/organizations/{org}/Users/{scim_user_id}": Operation<
-    "/scim/v2/organizations/{org}/Users/{scim_user_id}",
     "put"
   >;
   /**

--- a/test.ts
+++ b/test.ts
@@ -36,11 +36,9 @@ assertNullableString(resultMerge2.url);
 const test = {} as Endpoints["GET /repos/{owner}/{repo}/issues"]["response"];
 assertArray(test.data);
 assertString(test.data[0].assignees![0].avatar_url);
-const test2 = {} as Endpoints["GET /scim/v2/organizations/{org}/Users"]["response"];
-assertNullableString(test2.data.Resources[0].name.givenName);
 
-const test3 = {} as Endpoints["POST /user/repos"]["parameters"];
-assertString(test3.name);
+const test2 = {} as Endpoints["POST /user/repos"]["parameters"];
+assertString(test2.name);
 
 const checkRunsRoute = 'GET /repos/{owner}/{repo}/commits/{ref}/check-runs' as const;
 


### PR DESCRIPTION
* feat: add support for new "Delete an organization secret"  (`DELETE /organizations/{org}/codespaces/secrets/{secret_name}`) Codespaces API
* feat: add support for new "Remove selected repository from an organization secret" (`DELETE /organizations/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}`) Codespaces API
* feat: add support for new "List organization secrets" (`GET /organizations/{org}/codespaces/secrets`) Codespaces API
* feat: add support for new "Get an organization public key" (`GET /organizations/{org}/codespaces/secrets/public-key`) Codespaces API
* feat: add support for new "Get an organization secret" (`GET /organizations/{org}/codespaces/secrets/{secret_name}` ) Codespaces API
* feat: add support for new "List selected repositories for an organization secret" (`GET /organizations/{org}/codespaces/secrets/{secret_name}/repositories`) Codespaces API
* feat: add support for new "Get a Dependabot alert" API (`GET /repos/{owner}/{repo}/dependabot/alerts/{alert_number}`)
* feat: add support for new "List Dependabot alerts for a repository" API (`GET /repos/{owner}/{repo}/dependabot/alerts`)
* feat: add support for new "Update a Dependabot alert" API (`PATCH /repos/{owner}/{repo}/dependabot/alerts/{alert_number}`)
* feat: adds support for new "Create or update an organization secret" (`PUT /organizations/{org}/codespaces/secrets/{secret_name}` ) Codespaces API
* feat: add support for new "List selected repositories for an organization secret" (`GET /organizations/{org}/codespaces/secrets/{secret_name}/repositories`) Codespaces API
* feat: add support for new "Add selected repository to an organization secret" (`PUT /organizations/{org}/codespaces/secrets/{secret_name}/repositories/{repository_id}`) Codespaces API

BREAKING CHANGE: This drops support for a number of APIs which are only available in GitHub Enterprise Server (GHES) and GitHub Enterprise Cloud (GHEC). If you want to use these APIs and/or see TypeScript errors after upgrading to this version, you may need to start using the [`@octokit/plugin-enterprise-cloud`](https://github.com/octokit/plugin-enterprise-cloud.js) and/or [`@octokit/plugin-enterprise-server`](https://github.com/octokit/plugin-enterprise-server.js) packages.