### PR TITLE
Revert "feat: remove previews (#491)"

### DIFF
--- a/scripts/update-endpoints/fetch-json.js
+++ b/scripts/update-endpoints/fetch-json.js
@@ -22,6 +22,9 @@ const QUERY = `
         in
         name
       }
+      previews(required: true) {
+        name
+      }
       renamed {
         note
       }

--- a/scripts/update-endpoints/generated/endpoints.json
+++ b/scripts/update-endpoints/generated/endpoints.json
@@ -8,6 +8,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "labels" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -20,6 +21,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "labels" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -41,6 +43,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -57,6 +60,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -68,6 +72,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "run_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -79,6 +84,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "run_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -112,6 +118,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "key_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -141,6 +148,7 @@
         "name": "selected_repository_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -164,6 +172,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "key_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -173,6 +182,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -183,6 +193,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -192,6 +203,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -202,6 +214,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -238,6 +251,7 @@
         "name": "selected_workflows"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -257,6 +271,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "inputs" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "inputs.*" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -268,6 +283,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "cache_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -280,6 +296,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "key" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -291,6 +308,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "artifact_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -312,6 +330,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -322,6 +341,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -333,6 +353,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -343,6 +364,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -354,6 +376,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -369,6 +392,7 @@
         "name": "runner_group_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -380,6 +404,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "run_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -391,6 +416,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "run_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -406,6 +432,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -417,6 +444,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "workflow_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -439,6 +467,7 @@
         "name": "archive_format"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -450,6 +479,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "job_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -467,6 +497,7 @@
         "name": "attempt_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -478,6 +509,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "run_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -493,6 +525,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -504,6 +537,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "workflow_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -520,6 +554,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "sort" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "direction" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -530,6 +565,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -541,6 +577,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -550,6 +587,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -559,6 +597,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -568,6 +607,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -578,6 +618,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -589,6 +630,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "artifact_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -609,6 +651,7 @@
         "name": "environment_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -630,6 +673,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -639,6 +683,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -648,6 +693,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -658,6 +704,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -667,6 +714,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -677,6 +725,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -688,6 +737,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "job_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -697,6 +747,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -707,6 +758,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -718,6 +770,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "run_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -728,6 +781,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -738,6 +792,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -749,6 +804,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -760,6 +816,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "run_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -770,6 +827,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -781,6 +839,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -796,6 +855,7 @@
         "name": "runner_group_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -807,6 +867,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "workflow_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -817,6 +878,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -834,6 +896,7 @@
         "name": "exclude_pull_requests"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -857,6 +920,7 @@
         "name": "exclude_pull_requests"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -868,6 +932,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "run_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -879,6 +944,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "workflow_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -891,6 +957,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -913,6 +980,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -927,6 +995,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -946,6 +1015,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -956,6 +1026,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -967,6 +1038,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -978,6 +1050,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -995,6 +1068,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1007,6 +1081,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1019,6 +1094,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1028,6 +1104,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1038,6 +1115,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1055,6 +1133,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1066,6 +1145,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1083,6 +1163,7 @@
         "name": "visible_to_repository"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1094,6 +1175,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1106,6 +1188,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1123,6 +1206,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1136,6 +1220,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1172,6 +1257,7 @@
       },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "head_sha" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1202,6 +1288,7 @@
       },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "head_sha" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1219,6 +1306,7 @@
         "name": "enable_debug_logging"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1236,6 +1324,7 @@
         "name": "enable_debug_logging"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1253,6 +1342,7 @@
         "name": "enable_debug_logging"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1263,6 +1353,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1274,6 +1365,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1285,6 +1377,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1297,6 +1390,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1318,6 +1412,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1339,6 +1434,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1355,6 +1451,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1374,6 +1471,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "state" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "comment" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1401,6 +1499,7 @@
         "name": "patterns_allowed"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1429,6 +1528,7 @@
         "name": "patterns_allowed"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1440,6 +1540,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "labels" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1452,6 +1553,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "labels" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1473,6 +1575,7 @@
         "name": "can_approve_pull_request_reviews"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1494,6 +1597,7 @@
         "name": "can_approve_pull_request_reviews"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1516,6 +1620,7 @@
         "name": "can_approve_pull_request_reviews"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1537,6 +1642,7 @@
         "name": "allowed_actions"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1554,6 +1660,7 @@
         "name": "allowed_actions"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1575,6 +1682,7 @@
         "name": "selected_repository_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1596,6 +1704,7 @@
         "name": "selected_repository_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1611,6 +1720,7 @@
         "name": "selected_repository_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1627,6 +1737,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "runners" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1643,6 +1754,7 @@
         "name": "access_level"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1678,6 +1790,7 @@
         "name": "selected_workflows"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1688,6 +1801,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1698,6 +1812,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1707,6 +1822,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "thread_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1714,6 +1830,7 @@
     "url": "/feeds",
     "documentationUrl": "https://docs.github.com/rest/reference/activity#get-feeds",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1724,6 +1841,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1733,6 +1851,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "thread_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1742,6 +1861,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "thread_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1753,6 +1873,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1772,6 +1893,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1784,6 +1906,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1794,6 +1917,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1806,6 +1930,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1817,6 +1942,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1828,6 +1954,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1839,6 +1966,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1850,6 +1978,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1862,6 +1991,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1883,6 +2013,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1895,6 +2026,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1908,6 +2040,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1919,6 +2052,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1931,6 +2065,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1941,6 +2076,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1953,6 +2089,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1968,6 +2105,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "read" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1984,6 +2122,7 @@
         "name": "last_read_at"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -1993,6 +2132,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "thread_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2005,6 +2145,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "subscribed" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "ignored" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2015,6 +2156,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "thread_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "ignored" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2025,6 +2167,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2035,6 +2178,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2055,6 +2199,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -2075,6 +2220,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2090,6 +2236,7 @@
         "name": "access_token"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2099,6 +2246,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "code" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2317,6 +2465,7 @@
         "name": "permissions.team_discussions"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2332,6 +2481,7 @@
         "name": "access_token"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2346,6 +2496,7 @@
         "name": "installation_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2361,6 +2512,7 @@
         "name": "access_token"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2368,6 +2520,7 @@
     "url": "/app",
     "documentationUrl": "https://docs.github.com/rest/reference/apps#get-the-authenticated-app",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2377,6 +2530,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "app_slug" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2391,6 +2545,7 @@
         "name": "installation_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2400,6 +2555,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2410,6 +2566,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2419,6 +2576,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "account_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2428,6 +2586,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "account_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2437,6 +2596,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2444,6 +2604,7 @@
     "url": "/app/hook/config",
     "documentationUrl": "https://docs.github.com/rest/reference/apps#get-a-webhook-configuration-for-an-app",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2453,6 +2614,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "delivery_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2466,6 +2628,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2479,6 +2642,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2495,6 +2659,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2507,6 +2672,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "since" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "outdated" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2517,6 +2683,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2527,6 +2694,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2537,6 +2705,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2547,6 +2716,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2557,6 +2727,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2567,6 +2738,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2577,6 +2749,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "cursor" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2586,6 +2759,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "delivery_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2606,6 +2780,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -2626,6 +2801,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2641,6 +2817,7 @@
         "name": "access_token"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2648,6 +2825,7 @@
     "url": "/installation/token",
     "documentationUrl": "https://docs.github.com/rest/reference/apps#revoke-an-installation-access-token",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2869,6 +3047,7 @@
         "name": "permissions.team_discussions"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2883,6 +3062,7 @@
         "name": "installation_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2897,6 +3077,7 @@
         "name": "installation_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2919,6 +3100,7 @@
         "name": "insecure_ssl"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2928,6 +3110,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2937,6 +3120,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2948,6 +3132,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2959,6 +3144,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2968,6 +3154,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2977,6 +3164,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2986,6 +3174,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -2995,6 +3184,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3007,6 +3197,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "status" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "*" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3018,6 +3209,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "head_sha" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3034,6 +3226,7 @@
         "name": "check_run_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3050,6 +3243,7 @@
         "name": "check_suite_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3068,6 +3262,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3090,6 +3285,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "app_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3116,6 +3312,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3136,6 +3333,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3152,6 +3350,7 @@
         "name": "check_run_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3168,6 +3367,7 @@
         "name": "check_suite_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3196,6 +3396,7 @@
         "name": "auto_trigger_checks[].setting"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3356,6 +3557,7 @@
         "name": "actions[].identifier"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3378,6 +3580,7 @@
         "name": "confirm_delete"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3400,6 +3603,7 @@
         "name": "alert_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3411,6 +3615,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "analysis_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3422,6 +3627,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "language" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3433,6 +3639,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "sarif_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3452,6 +3659,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3470,6 +3678,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "state" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "sort" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3488,6 +3697,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "state" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "sort" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3506,6 +3716,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "sort" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "state" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3525,6 +3736,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "ref" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -3535,6 +3747,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3553,6 +3766,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "direction" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "sort" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3582,6 +3796,7 @@
         "name": "dismissed_comment"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3603,6 +3818,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "started_at" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "tool_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3610,6 +3826,7 @@
     "url": "/codes_of_conduct",
     "documentationUrl": "https://docs.github.com/rest/reference/codes-of-conduct#get-all-codes-of-conduct",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3619,6 +3836,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "key" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3639,6 +3857,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3660,6 +3879,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3674,6 +3894,7 @@
         "name": "codespace_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3746,6 +3967,7 @@
         "name": "pull_request.repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3775,6 +3997,7 @@
         "name": "selected_repository_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3798,6 +4021,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "key_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3825,6 +4049,7 @@
         "name": "selected_repository_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3880,6 +4105,7 @@
         "name": "retention_period_minutes"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3930,6 +4156,7 @@
         "name": "retention_period_minutes"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3944,6 +4171,7 @@
         "name": "codespace_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3960,6 +4188,7 @@
         "name": "codespace_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3970,6 +4199,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3981,6 +4211,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -3990,6 +4221,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4004,6 +4236,7 @@
         "name": "codespace_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4019,6 +4252,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "export_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4033,6 +4267,7 @@
         "name": "codespace_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4042,6 +4277,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4052,6 +4288,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4059,6 +4296,7 @@
     "url": "/user/codespaces/secrets/public-key",
     "documentationUrl": "https://docs.github.com/rest/reference/codespaces#get-public-key-for-the-authenticated-user",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4069,6 +4307,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4080,6 +4319,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4089,6 +4329,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4101,6 +4342,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4117,6 +4359,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4129,6 +4372,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": "org", "deprecated": true, "in": "PATH", "name": "org_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4141,6 +4385,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4152,6 +4397,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4164,6 +4410,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4173,6 +4420,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4183,6 +4431,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4200,6 +4449,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4212,6 +4462,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "ref" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "client_ip" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4232,6 +4483,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4253,6 +4505,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4265,6 +4518,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "location" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "client_ip" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4285,6 +4539,7 @@
         "name": "selected_repository_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4306,6 +4561,7 @@
         "name": "selected_repository_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4320,6 +4576,7 @@
         "name": "codespace_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4334,6 +4591,7 @@
         "name": "codespace_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4350,6 +4608,7 @@
         "name": "codespace_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4377,6 +4636,7 @@
         "name": "recent_folders"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4398,6 +4658,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4427,6 +4688,7 @@
         "name": "selected_repository_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4450,6 +4712,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "key_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4460,6 +4723,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4471,6 +4735,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4487,6 +4752,7 @@
         "name": "alert_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4496,6 +4762,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4506,6 +4773,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4516,6 +4784,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4527,6 +4796,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "secret_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4547,6 +4817,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4558,6 +4829,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4570,6 +4842,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4587,6 +4860,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4608,6 +4882,7 @@
         "name": "repository_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4629,6 +4904,7 @@
         "name": "selected_repository_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4658,6 +4934,7 @@
         "name": "dismissed_comment"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4792,6 +5069,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "scanned" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4804,6 +5082,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "basehead" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4811,6 +5090,7 @@
     "url": "/emojis",
     "documentationUrl": "https://docs.github.com/rest/reference/emojis#get-emojis",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4822,6 +5102,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "labels" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4838,6 +5119,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4854,6 +5136,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4863,6 +5146,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4872,6 +5156,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4908,6 +5193,7 @@
         "name": "selected_workflows"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4918,6 +5204,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4933,6 +5220,7 @@
         "name": "runner_group_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4943,6 +5231,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4953,6 +5242,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4962,6 +5252,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4971,6 +5262,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4981,6 +5273,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -4996,6 +5289,7 @@
         "name": "runner_group_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5017,6 +5311,7 @@
       },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "date_end" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5027,6 +5322,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5044,6 +5340,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5053,6 +5350,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5064,6 +5362,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5081,6 +5380,7 @@
         "name": "visible_to_organization"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5092,6 +5392,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5109,6 +5410,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5119,6 +5421,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enterprise" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5130,6 +5433,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5146,6 +5450,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5162,6 +5467,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5189,6 +5495,7 @@
         "name": "patterns_allowed"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5200,6 +5507,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "runner_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "labels" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5221,6 +5529,7 @@
         "name": "allowed_actions"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5242,6 +5551,7 @@
         "name": "selected_organization_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5257,6 +5567,7 @@
         "name": "selected_organization_ids"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5273,6 +5584,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "runners" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5308,6 +5620,7 @@
         "name": "selected_workflows"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5317,6 +5630,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gist_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5340,6 +5654,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "public" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5350,6 +5665,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gist_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5359,6 +5675,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gist_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5369,6 +5686,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gist_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5378,6 +5696,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gist_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5387,6 +5706,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gist_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5397,6 +5717,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gist_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5407,6 +5728,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gist_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "sha" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5418,6 +5740,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5429,6 +5752,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5440,6 +5764,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5452,6 +5777,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5463,6 +5789,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5474,6 +5801,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5485,6 +5813,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5494,6 +5823,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gist_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5503,6 +5833,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gist_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5532,6 +5863,7 @@
         "name": "files.*.filename"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5543,6 +5875,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5555,6 +5888,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "content" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "encoding" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5607,6 +5941,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "signature" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5620,6 +5955,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "sha" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "key" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5648,6 +5984,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "tagger.date" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5685,6 +6022,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "base_tree" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5696,6 +6034,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5707,6 +6046,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "file_sha" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5718,6 +6058,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "commit_sha" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5729,6 +6070,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5740,6 +6082,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "tag_sha" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5752,6 +6095,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "tree_sha" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "recursive" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5763,6 +6107,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5776,6 +6121,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "sha" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "force" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5783,6 +6129,7 @@
     "url": "/gitignore/templates",
     "documentationUrl": "https://docs.github.com/rest/reference/gitignore#get-all-gitignore-templates",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5792,6 +6139,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5799,6 +6147,7 @@
     "url": "/user/interaction-limits",
     "documentationUrl": "https://docs.github.com/rest/reference/interactions#get-interaction-restrictions-for-your-public-repositories",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5808,6 +6157,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5818,6 +6168,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5825,6 +6176,7 @@
     "url": "/user/interaction-limits",
     "documentationUrl": "https://docs.github.com/rest/reference/interactions#get-interaction-restrictions-for-your-public-repositories",
     "parameters": [],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -5832,6 +6184,7 @@
     "url": "/user/interaction-limits",
     "documentationUrl": "https://docs.github.com/rest/reference/interactions#remove-interaction-restrictions-from-your-public-repositories",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5841,6 +6194,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5851,6 +6205,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5858,6 +6213,7 @@
     "url": "/user/interaction-limits",
     "documentationUrl": "https://docs.github.com/rest/reference/interactions#remove-interaction-restrictions-from-your-public-repositories",
     "parameters": [],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -5868,6 +6224,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "limit" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "expiry" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5879,6 +6236,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "limit" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "expiry" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5891,6 +6249,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "limit" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "expiry" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5901,6 +6260,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "limit" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "expiry" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -5918,6 +6278,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "assignees" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5941,6 +6302,7 @@
         "name": "labels[].name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5952,6 +6314,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "assignee" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5968,6 +6331,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "labels" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "assignees" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5985,6 +6349,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -5998,6 +6363,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "color" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "description" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6017,6 +6383,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "due_on" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6028,6 +6395,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6039,6 +6407,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6055,6 +6424,7 @@
         "name": "milestone_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6071,6 +6441,7 @@
         "name": "issue_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6082,6 +6453,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6093,6 +6465,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "event_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6104,6 +6477,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6120,6 +6494,7 @@
         "name": "milestone_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6140,6 +6515,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6152,6 +6528,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6171,6 +6548,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6186,6 +6564,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6204,6 +6583,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6216,6 +6596,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6234,6 +6615,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6250,6 +6632,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6267,6 +6650,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6288,6 +6672,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6306,6 +6691,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6318,6 +6704,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6336,6 +6723,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6351,6 +6739,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6368,6 +6757,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "lock_reason" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6384,6 +6774,7 @@
         "name": "issue_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6401,6 +6792,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "assignees" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6418,6 +6810,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6441,6 +6834,7 @@
         "name": "labels[].name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6457,6 +6851,7 @@
         "name": "issue_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6486,6 +6881,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "labels" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "assignees" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6498,6 +6894,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6512,6 +6909,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "color" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "description" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6537,6 +6935,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "due_on" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6546,6 +6945,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "license" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6557,6 +6957,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6567,6 +6968,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6578,6 +6980,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "mode" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "context" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6587,6 +6990,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "BODY", "name": "data" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6594,6 +6998,7 @@
     "url": "/meta",
     "documentationUrl": "https://docs.github.com/rest/reference/meta#get-github-meta-information",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6603,6 +7008,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "s" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6610,6 +7016,7 @@
     "url": "/zen",
     "documentationUrl": "",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6617,6 +7024,7 @@
     "url": "/",
     "documentationUrl": "https://docs.github.com/rest/overview/resources-in-the-rest-api#root-endpoint",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6627,6 +7035,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6641,6 +7050,7 @@
         "name": "migration_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6656,6 +7066,7 @@
         "name": "migration_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6671,6 +7082,7 @@
         "name": "migration_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6685,6 +7097,7 @@
         "name": "migration_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6696,6 +7109,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "since" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6706,6 +7120,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6716,6 +7131,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6731,6 +7147,7 @@
       },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "exclude" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6747,6 +7164,7 @@
       },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "exclude" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6757,6 +7175,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6769,6 +7188,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "exclude" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6785,6 +7205,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6802,6 +7223,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6818,6 +7240,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -6831,6 +7254,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "email" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6842,6 +7266,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "use_lfs" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6899,6 +7324,7 @@
         "name": "repositories"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6957,6 +7383,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "exclude" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -6987,6 +7414,7 @@
         "name": "tfvc_project"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7002,6 +7430,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7018,6 +7447,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7047,6 +7477,7 @@
         "name": "tfvc_project"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7057,6 +7488,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7067,6 +7499,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7082,6 +7515,7 @@
         "name": "invitation_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7092,6 +7526,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7102,6 +7537,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7112,6 +7548,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7123,6 +7560,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "async" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7141,6 +7579,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "base_role" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "permissions" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7154,6 +7593,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "role" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "team_ids" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7198,6 +7638,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "events" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "active" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7208,6 +7649,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "role_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7218,6 +7660,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7234,6 +7677,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "enablement" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7243,6 +7687,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7252,6 +7697,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7262,6 +7708,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7272,6 +7719,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7282,6 +7730,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7293,6 +7742,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "delivery_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7303,6 +7753,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "since" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7314,6 +7765,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7323,6 +7775,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7337,6 +7790,7 @@
         "name": "organization_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7348,6 +7802,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7357,6 +7812,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7367,6 +7823,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7378,6 +7835,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7395,6 +7853,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7408,6 +7867,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7419,6 +7879,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7431,6 +7892,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7442,6 +7904,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7453,6 +7916,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7462,6 +7926,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7474,6 +7939,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "cursor" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7485,6 +7951,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7495,6 +7962,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7506,6 +7974,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "delivery_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7516,6 +7985,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7526,6 +7996,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7536,6 +8007,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7546,6 +8018,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7556,6 +8029,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7567,6 +8041,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "role" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7577,6 +8052,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7587,6 +8063,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7733,6 +8210,7 @@
         "name": "secret_scanning_push_protection_enabled_for_new_repositories"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7752,6 +8230,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "base_role" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "permissions" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7762,6 +8241,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "state" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7795,6 +8275,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "active" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7819,6 +8300,7 @@
         "name": "insecure_ssl"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7839,6 +8321,7 @@
         "name": "package_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7860,6 +8343,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7881,6 +8365,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7907,6 +8392,7 @@
         "name": "package_version_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7934,6 +8420,7 @@
         "name": "package_version_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7961,6 +8448,7 @@
         "name": "package_version_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -7985,6 +8473,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "state" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -8008,6 +8497,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "state" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -8031,6 +8521,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "state" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8055,6 +8546,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "state" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8076,6 +8568,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8096,6 +8589,7 @@
         "name": "package_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8117,6 +8611,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8138,6 +8633,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8164,6 +8660,7 @@
         "name": "package_version_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8191,6 +8688,7 @@
         "name": "package_version_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8218,6 +8716,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8233,6 +8732,7 @@
       },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "visibility" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8249,6 +8749,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "visibility" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8270,6 +8771,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8291,6 +8793,7 @@
       },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "token" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8313,6 +8816,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "token" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8335,6 +8839,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "token" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8361,6 +8866,7 @@
         "name": "package_version_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8388,6 +8894,7 @@
         "name": "package_version_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8415,6 +8922,7 @@
         "name": "package_version_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8426,6 +8934,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "permission" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8443,6 +8952,7 @@
         "name": "content_type"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8453,6 +8963,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "project_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8463,6 +8974,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "name" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8474,6 +8986,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "name" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8486,6 +8999,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "name" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8495,6 +9009,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "project_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8504,6 +9019,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "card_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8513,6 +9029,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "column_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8522,6 +9039,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "project_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8531,6 +9049,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "card_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8540,6 +9059,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "column_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8550,6 +9070,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "project_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8567,6 +9088,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8584,6 +9106,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8595,6 +9118,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8607,6 +9131,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8620,6 +9145,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8632,6 +9158,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8643,6 +9170,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "position" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "column_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8653,6 +9181,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "column_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "position" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8663,6 +9192,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "project_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8682,6 +9212,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "private" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8693,6 +9224,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "note" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "archived" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8703,6 +9235,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "column_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8714,6 +9247,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "pull_number" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8736,6 +9270,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "draft" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "issue" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8754,6 +9289,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8816,6 +9352,7 @@
         "name": "comments[].start_side"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8841,6 +9378,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "start_side" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "in_reply_to" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8858,6 +9396,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "review_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8869,6 +9408,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8888,6 +9428,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "message" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "event" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8899,6 +9440,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "pull_number" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8916,6 +9458,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "review_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8927,6 +9470,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8944,6 +9488,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8963,6 +9508,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8981,6 +9527,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -8999,6 +9546,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9010,6 +9558,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "pull_number" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9031,6 +9580,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9046,6 +9596,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9064,6 +9615,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9099,6 +9651,7 @@
         "name": "merge_method"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9122,6 +9675,7 @@
         "name": "team_reviewers"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9145,6 +9699,7 @@
         "name": "team_reviewers"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9164,6 +9719,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "event" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9190,6 +9746,7 @@
         "name": "maintainer_can_modify"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9212,6 +9769,7 @@
         "name": "expected_head_sha"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9230,6 +9788,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "review_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9242,6 +9801,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9249,6 +9809,7 @@
     "url": "/rate_limit",
     "documentationUrl": "https://docs.github.com/rest/reference/rate-limit#get-rate-limit-status-for-the-authenticated-user",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9261,6 +9822,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "content" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9278,6 +9840,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "content" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9290,6 +9853,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "content" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9302,6 +9866,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "content" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9314,6 +9879,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "release_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "content" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9337,6 +9903,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "content" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9359,6 +9926,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "content" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9376,6 +9944,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "content" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9392,6 +9961,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "content" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9404,6 +9974,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "reaction_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9421,6 +9992,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "reaction_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9433,6 +10005,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "reaction_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9445,6 +10018,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "reaction_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9457,6 +10031,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "release_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "reaction_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9474,6 +10049,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "reaction_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9497,6 +10073,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "reaction_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9511,6 +10088,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9530,6 +10108,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9544,6 +10123,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9558,6 +10138,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9572,6 +10153,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9597,6 +10179,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9621,6 +10204,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9640,6 +10224,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9658,6 +10243,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9672,6 +10258,7 @@
         "name": "invitation_id"
       }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -9686,6 +10273,7 @@
         "name": "invitation_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9698,6 +10286,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "apps" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9710,6 +10299,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "permission" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9722,6 +10312,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "contexts" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9734,6 +10325,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "teams" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9746,6 +10338,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "users" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9757,6 +10350,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9767,6 +10361,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9778,6 +10373,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9792,6 +10388,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9805,6 +10402,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "basehead" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9828,6 +10426,7 @@
         "name": "is_alphanumeric"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9843,6 +10442,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "position" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "line" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9854,6 +10454,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9874,6 +10475,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "context" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9887,6 +10489,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "key" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "read_only" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9931,6 +10534,7 @@
         "name": "production_environment"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9948,6 +10552,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -9991,6 +10596,7 @@
         "name": "auto_inactive"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10014,6 +10620,7 @@
         "name": "client_payload.*"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10114,6 +10721,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "is_template" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10137,6 +10745,7 @@
         "name": "default_branch_only"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10244,6 +10853,7 @@
         "name": "merge_commit_message"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10292,6 +10902,7 @@
         "name": "deployment_branch_policy.custom_branch_policies"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10340,6 +10951,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "author.date" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10369,6 +10981,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "oidc_token" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10388,6 +11001,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "source.path" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10421,6 +11035,7 @@
         "name": "generate_release_notes"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10432,6 +11047,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "pattern" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10467,6 +11083,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "private" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10512,6 +11129,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "events" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "active" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10526,6 +11144,7 @@
         "name": "invitation_id"
       }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -10540,6 +11159,7 @@
         "name": "invitation_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10550,6 +11170,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10561,6 +11182,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10572,6 +11194,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10588,6 +11211,7 @@
         "name": "environment_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10599,6 +11223,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "autolink_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10610,6 +11235,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10621,6 +11247,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10632,6 +11259,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10643,6 +11271,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "key_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10659,6 +11288,7 @@
         "name": "deployment_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10681,6 +11311,7 @@
         "name": "branch_policy_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10721,6 +11352,7 @@
         "name": "author.email"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10737,6 +11369,7 @@
         "name": "invitation_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10747,6 +11380,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10758,6 +11392,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10769,6 +11404,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "release_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10780,6 +11416,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "asset_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10796,6 +11433,7 @@
         "name": "tag_protection_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10807,6 +11445,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10817,6 +11456,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10827,6 +11467,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10837,6 +11478,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10848,6 +11490,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "ref" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -10859,6 +11502,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "ref" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -10870,6 +11514,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10881,6 +11526,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10891,6 +11537,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10901,6 +11548,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10911,6 +11559,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10940,6 +11589,7 @@
         "name": "configuration_file_path"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10950,6 +11600,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10961,6 +11612,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10972,6 +11624,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10984,6 +11637,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -10995,6 +11649,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11007,6 +11662,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11018,6 +11674,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11029,6 +11686,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "autolink_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11040,6 +11698,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11051,6 +11710,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11062,6 +11722,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11072,6 +11733,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11083,6 +11745,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11096,6 +11759,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11109,6 +11773,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11119,6 +11784,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11130,6 +11796,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11141,6 +11808,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11151,6 +11819,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11163,6 +11832,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "path" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11173,6 +11843,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11184,6 +11855,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "key_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11200,6 +11872,7 @@
         "name": "deployment_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11222,6 +11895,7 @@
         "name": "branch_policy_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11239,6 +11913,7 @@
       },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "status_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11255,6 +11930,7 @@
         "name": "environment_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11265,6 +11941,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11275,6 +11952,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11285,6 +11963,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11296,6 +11975,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "build_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11306,6 +11986,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11316,6 +11997,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11327,6 +12009,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11337,6 +12020,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11348,6 +12032,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11360,6 +12045,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "dir" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "ref" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11371,6 +12057,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "release_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11382,6 +12069,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "asset_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11393,6 +12081,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "tag" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11404,6 +12093,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11415,6 +12105,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11425,6 +12116,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11435,6 +12127,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11446,6 +12139,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11457,6 +12151,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11468,6 +12163,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11479,6 +12175,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11491,6 +12188,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "delivery_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11502,6 +12200,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11515,6 +12214,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11526,6 +12226,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "commit_sha" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11550,6 +12251,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11563,6 +12265,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11575,6 +12278,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11588,6 +12292,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11605,6 +12310,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11618,6 +12324,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11630,6 +12337,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11648,6 +12356,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11666,6 +12375,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11687,6 +12397,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11714,6 +12425,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "since" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "before" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11728,6 +12440,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11742,6 +12455,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11755,6 +12469,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11767,6 +12482,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11777,6 +12493,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11787,6 +12504,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11799,6 +12517,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11808,6 +12527,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "since" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11821,6 +12541,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11834,6 +12555,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11846,6 +12568,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11856,6 +12579,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11868,6 +12592,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11880,6 +12605,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11893,6 +12619,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "cursor" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11905,6 +12632,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11923,6 +12651,7 @@
         "name": "commit_message"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11934,6 +12663,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11945,6 +12675,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11957,6 +12688,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "delivery_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11969,6 +12701,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "apps" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11980,6 +12713,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -11992,6 +12726,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "contexts" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12003,6 +12738,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12015,6 +12751,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "teams" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12027,6 +12764,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "users" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12039,6 +12777,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "new_name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12050,6 +12789,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "names" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12060,6 +12800,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12071,6 +12812,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12083,6 +12825,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "apps" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12095,6 +12838,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "contexts" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12107,6 +12851,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "teams" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12119,6 +12864,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "branch" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "users" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12130,6 +12876,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "hook_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12142,6 +12889,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "new_owner" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "team_ids" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12303,6 +13051,7 @@
         "name": "web_commit_signoff_required"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12482,6 +13231,7 @@
         "name": "required_conversation_resolution"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12494,6 +13244,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "comment_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12517,6 +13268,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "name" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12537,6 +13289,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "build_type" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "source" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12554,6 +13307,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "permissions" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12631,6 +13385,7 @@
         "name": "bypass_pull_request_allowances.apps"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12659,6 +13414,7 @@
         "name": "discussion_category_name"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12673,6 +13429,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "label" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "state" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12699,6 +13456,7 @@
         "name": "checks[].app_id"
       }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -12725,6 +13483,7 @@
         "name": "checks[].app_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12777,6 +13536,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "active" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12802,6 +13562,7 @@
         "name": "insecure_ssl"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12817,6 +13578,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "data" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "origin" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12830,6 +13592,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12843,6 +13606,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12856,6 +13620,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12875,6 +13640,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12888,6 +13654,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12899,6 +13666,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12912,6 +13680,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12928,6 +13697,7 @@
         "name": "alert_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12955,6 +13725,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "before" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "after" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -12983,6 +13754,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "before" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "after" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13012,6 +13784,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "before" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "after" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13030,6 +13803,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13054,6 +13828,7 @@
         "name": "resolution_comment"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13064,6 +13839,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13076,6 +13852,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "role" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13087,6 +13864,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "role" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13099,6 +13877,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "project_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "permission" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13110,6 +13889,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "project_id" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "permission" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13123,6 +13903,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "permission" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13135,6 +13916,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "permission" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13146,6 +13928,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "project_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13156,6 +13939,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "project_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13168,6 +13952,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13179,6 +13964,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13210,6 +13996,7 @@
         "name": "parent_team_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13227,6 +14014,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13243,6 +14031,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13256,6 +14045,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "private" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13268,6 +14058,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "private" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13290,6 +14081,7 @@
         "name": "comment_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13311,6 +14103,7 @@
         "name": "comment_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13327,6 +14120,7 @@
         "name": "discussion_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13342,6 +14136,7 @@
         "name": "discussion_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13352,6 +14147,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13361,6 +14157,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13371,6 +14168,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "org" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13393,6 +14191,7 @@
         "name": "comment_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13414,6 +14213,7 @@
         "name": "comment_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13430,6 +14230,7 @@
         "name": "discussion_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13445,6 +14246,7 @@
         "name": "discussion_number"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13454,6 +14256,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13464,6 +14267,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13475,6 +14279,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13485,6 +14290,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13496,6 +14302,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13508,6 +14315,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13519,6 +14327,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13538,6 +14347,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13556,6 +14366,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13570,6 +14381,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "pinned" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13582,6 +14394,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13592,6 +14405,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13605,6 +14419,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13617,6 +14432,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13629,6 +14445,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13640,6 +14457,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13652,6 +14470,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13663,6 +14482,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13675,6 +14495,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13686,6 +14507,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13696,6 +14518,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13707,6 +14530,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13717,6 +14541,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13728,6 +14553,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_slug" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "project_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13738,6 +14564,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "team_id" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "project_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13750,6 +14577,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13761,6 +14589,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "owner" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "repo" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13784,6 +14613,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13806,6 +14636,7 @@
       },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13824,6 +14655,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "title" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13841,6 +14673,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "title" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "body" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13866,6 +14699,7 @@
         "name": "parent_team_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13890,6 +14724,7 @@
         "name": "parent_team_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13899,6 +14734,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "BODY", "name": "emails" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -13908,6 +14744,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "BODY", "name": "emails" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13917,6 +14754,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13926,6 +14764,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13936,6 +14775,7 @@
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" },
       { "alias": null, "deprecated": null, "in": "PATH", "name": "target_user" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13945,6 +14785,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13960,6 +14801,7 @@
         "name": "armored_public_key"
       }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -13975,6 +14817,7 @@
         "name": "armored_public_key"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -13985,6 +14828,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "title" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "key" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -13995,6 +14839,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "title" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "key" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14005,6 +14850,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "title" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "key" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14014,6 +14860,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "BODY", "name": "emails" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14023,6 +14870,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "BODY", "name": "emails" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14032,6 +14880,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gpg_key_id" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14041,6 +14890,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gpg_key_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14050,6 +14900,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "key_id" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14059,6 +14910,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "key_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14073,6 +14925,7 @@
         "name": "ssh_signing_key_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14082,6 +14935,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14089,6 +14943,7 @@
     "url": "/user",
     "documentationUrl": "https://docs.github.com/rest/reference/users#get-the-authenticated-user",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14098,6 +14953,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14114,6 +14970,7 @@
       },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "subject_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14123,6 +14980,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gpg_key_id" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14132,6 +14990,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "gpg_key_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14141,6 +15000,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "key_id" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14150,6 +15010,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "key_id" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14164,6 +15025,7 @@
         "name": "ssh_signing_key_id"
       }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14174,6 +15036,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "since" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14181,6 +15044,7 @@
     "url": "/user/blocks",
     "documentationUrl": "https://docs.github.com/rest/reference/users#list-users-blocked-by-the-authenticated-user",
     "parameters": [],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14188,6 +15052,7 @@
     "url": "/user/blocks",
     "documentationUrl": "https://docs.github.com/rest/reference/users#list-users-blocked-by-the-authenticated-user",
     "parameters": [],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14198,6 +15063,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14208,6 +15074,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14218,6 +15085,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14228,6 +15096,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14238,6 +15107,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14249,6 +15119,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14260,6 +15131,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14270,6 +15142,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14280,6 +15153,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14291,6 +15165,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14301,6 +15176,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14311,6 +15187,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14322,6 +15199,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14332,6 +15210,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14342,6 +15221,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14352,6 +15232,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14363,6 +15244,7 @@
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "per_page" },
       { "alias": null, "deprecated": null, "in": "QUERY", "name": "page" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14372,6 +15254,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "BODY", "name": "visibility" }
     ],
+    "previews": [],
     "renamed": { "note": null }
   },
   {
@@ -14381,6 +15264,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "BODY", "name": "visibility" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14390,6 +15274,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14399,6 +15284,7 @@
     "parameters": [
       { "alias": null, "deprecated": null, "in": "PATH", "name": "username" }
     ],
+    "previews": [],
     "renamed": null
   },
   {
@@ -14420,6 +15306,7 @@
       { "alias": null, "deprecated": null, "in": "BODY", "name": "hireable" },
       { "alias": null, "deprecated": null, "in": "BODY", "name": "bio" }
     ],
+    "previews": [],
     "renamed": null
   }
 ]

--- a/scripts/update-endpoints/templates/endpoints.ts.template
+++ b/scripts/update-endpoints/templates/endpoints.ts.template
@@ -37,11 +37,21 @@ type ExtractRequestBody<T> = "requestBody" extends keyof T
   : {};
 type ToOctokitParameters<T> = ExtractParameters<T> & ExtractRequestBody<T>;
 
+type RequiredPreview<T> = T extends string
+  ? {
+      mediaType: {
+        previews: [T, ...string[]];
+      };
+    }
+  : {};
+
 type Operation<
   Url extends keyof paths,
   Method extends keyof paths[Url],
+  preview = unknown
 > = {
-  parameters: ToOctokitParameters<paths[Url][Method]>;
+  parameters: ToOctokitParameters<paths[Url][Method]> &
+    RequiredPreview<preview>;
   request: {
     method: Method extends keyof MethodsMap ? MethodsMap[Method] : never;
     url: Url;
@@ -105,6 +115,7 @@ export interface Endpoints {
   "{{@key}}": Operation<
     "{{url}}",
     "{{method}}"
+    {{#requiredPreview}}, "{{.}}"{{/requiredPreview}}
   >,
   {{/each}}
 }

--- a/scripts/update-endpoints/typescript.js
+++ b/scripts/update-endpoints/typescript.js
@@ -37,6 +37,7 @@ async function run() {
     endpointsByRoute[route] = {
       method: endpoint.method.toLowerCase(),
       url: toOpenApiUrl(endpoint),
+      requiredPreview: (endpoint.previews[0] || {}).name,
       documentationUrl: endpoint.documentationUrl,
     };
 

--- a/src/AuthInterface.ts
+++ b/src/AuthInterface.ts
@@ -22,7 +22,7 @@ export interface AuthInterface<
     /**
      * Sends a request using the passed `request` instance
      *
-     * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.format`, `request`, or `baseUrl`.
+     * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
      */
     <T = any>(request: RequestInterface, options: EndpointOptions): Promise<
       OctokitResponse<T>
@@ -32,7 +32,7 @@ export interface AuthInterface<
      * Sends a request using the passed `request` instance
      *
      * @param {string} route Request method + URL. Example: `'GET /orgs/{org}'`
-     * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.format`, `request`, or `baseUrl`.
+     * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
      */
     <T = any>(
       request: RequestInterface,

--- a/src/EndpointDefaults.ts
+++ b/src/EndpointDefaults.ts
@@ -17,5 +17,6 @@ export type EndpointDefaults = RequestParameters & {
   };
   mediaType: {
     format: string;
+    previews: string[];
   };
 };

--- a/src/EndpointInterface.ts
+++ b/src/EndpointInterface.ts
@@ -9,7 +9,7 @@ export interface EndpointInterface<D extends object = object> {
   /**
    * Transforms a GitHub REST API endpoint into generic request options
    *
-   * @param {object} endpoint Must set `url` unless it's set defaults. Plus URL, query or body parameters, as well as `headers`, `mediaType.format`, `request`, or `baseUrl`.
+   * @param {object} endpoint Must set `url` unless it's set defaults. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
   <O extends RequestParameters = RequestParameters>(
     options: O & { method?: string } & ("url" extends keyof D
@@ -21,7 +21,7 @@ export interface EndpointInterface<D extends object = object> {
    * Transforms a GitHub REST API endpoint into generic request options
    *
    * @param {string} route Request method + URL. Example: `'GET /orgs/{org}'`
-   * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.format`, `request`, or `baseUrl`.
+   * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
   <
     R extends Route,
@@ -52,7 +52,7 @@ export interface EndpointInterface<D extends object = object> {
      * without transforming them into request options.
      *
      * @param {string} route Request method + URL. Example: `'GET /orgs/{org}'`
-     * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.format`, `request`, or `baseUrl`.
+     * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
      *
      */
     <
@@ -73,7 +73,7 @@ export interface EndpointInterface<D extends object = object> {
      * Merges current endpoint defaults with passed route and parameters,
      * without transforming them into request options.
      *
-     * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.format`, `request`, or `baseUrl`.
+     * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
      */
     <P extends RequestParameters = RequestParameters>(
       options: P
@@ -91,7 +91,7 @@ export interface EndpointInterface<D extends object = object> {
    * Stateless method to turn endpoint options into request options.
    * Calling `endpoint(options)` is the same as calling `endpoint.parse(endpoint.merge(options))`.
    *
-   * @param {object} options `method`, `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.format`, `request`, or `baseUrl`.
+   * @param {object} options `method`, `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
   parse: <O extends EndpointDefaults = EndpointDefaults>(
     options: O

--- a/src/RequestHeaders.ts
+++ b/src/RequestHeaders.ts
@@ -1,6 +1,6 @@
 export type RequestHeaders = {
   /**
-   * Avoid setting `headers.accept`, use `mediaType.format` option instead.
+   * Avoid setting `headers.accept`, use `mediaType.{format|previews}` option instead.
    */
   accept?: string;
   /**

--- a/src/RequestInterface.ts
+++ b/src/RequestInterface.ts
@@ -9,7 +9,7 @@ export interface RequestInterface<D extends object = object> {
   /**
    * Sends a request based on endpoint options
    *
-   * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.format`, `request`, or `baseUrl`.
+   * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
   <T = any, O extends RequestParameters = RequestParameters>(
     options: O & { method?: string } & ("url" extends keyof D
@@ -21,7 +21,7 @@ export interface RequestInterface<D extends object = object> {
    * Sends a request based on endpoint options
    *
    * @param {string} route Request method + URL. Example: `'GET /orgs/{org}'`
-   * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.format`, `request`, or `baseUrl`.
+   * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
   <R extends Route>(
     route: keyof Endpoints | R,

--- a/src/RequestParameters.ts
+++ b/src/RequestParameters.ts
@@ -24,6 +24,12 @@ export type RequestParameters = {
      * `json` by default. Can be `raw`, `text`, `html`, `full`, `diff`, `patch`, `sha`, `base64`. Depending on endpoint
      */
     format?: string;
+    /**
+     * Custom media type names of {@link https://developer.github.com/v3/media/|API Previews} without the `-preview` suffix.
+     * Example for single preview: `['squirrel-girl']`.
+     * Example for multiple previews: `['squirrel-girl', 'mister-fantastic']`.
+     */
+    previews?: string[];
   };
   /**
    * Pass custom meta information for the request. The `request` object will be returned as is.

--- a/src/generated/Endpoints.ts
+++ b/src/generated/Endpoints.ts
@@ -37,8 +37,21 @@ type ExtractRequestBody<T> = "requestBody" extends keyof T
   : {};
 type ToOctokitParameters<T> = ExtractParameters<T> & ExtractRequestBody<T>;
 
-type Operation<Url extends keyof paths, Method extends keyof paths[Url]> = {
-  parameters: ToOctokitParameters<paths[Url][Method]>;
+type RequiredPreview<T> = T extends string
+  ? {
+      mediaType: {
+        previews: [T, ...string[]];
+      };
+    }
+  : {};
+
+type Operation<
+  Url extends keyof paths,
+  Method extends keyof paths[Url],
+  preview = unknown
+> = {
+  parameters: ToOctokitParameters<paths[Url][Method]> &
+    RequiredPreview<preview>;
   request: {
     method: Method extends keyof MethodsMap ? MethodsMap[Method] : never;
     url: Url;


### PR DESCRIPTION
This reverts commit cb0835bc8a8c47bacdd361a793fce0fb197a12bc.

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->

This reverts #491 because removing the previews logic broke the build for our enterprise modules such as plugin-enterprise-server.js, because of old versions of GHE such as v3.2 and v3.3 (set to be deprecated next week).   

Also, because GraaphQL previews are not deprecated yet @octokit/core, @octokit/graphql, and octokit.js will need to be modified. 

I missed these things in my review, which is why I am reverting this changeset; so that we can modify the other libraries first and then remove this logic.


----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Previews logic was removed

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Previews logic has been reintroduced.

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Added the appropriate label for the given change

### Does this introduce a breaking change?

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:
* N/A
----

