### PR TITLE
build(deps): downgrade `sort-keys` to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "prettier": "^2.0.0",
         "semantic-release": "^20.0.0",
         "semantic-release-plugin-update-version-in-files": "^1.0.0",
-        "sort-keys": "^5.0.0",
+        "sort-keys": "^4.2.0",
         "string-to-jsdoc-comment": "^1.0.0",
         "typedoc": "^0.23.0",
         "typescript": "^4.0.2"
@@ -10363,30 +10363,27 @@
       }
     },
     "node_modules/sort-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.0.0.tgz",
-      "integrity": "sha512-Pdz01AvCAottHTPQGzndktFNdbRA75BgOfeT1hH+AMnJFv8lynkPi42rfeEhpx1saTEI3YNMWxfqu0sFD1G8pw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
+      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
       "dev": true,
       "dependencies": {
-        "is-plain-obj": "^4.0.0"
+        "is-plain-obj": "^2.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sort-keys/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true,
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/source-map": {
@@ -18902,18 +18899,18 @@
       "dev": true
     },
     "sort-keys": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.0.0.tgz",
-      "integrity": "sha512-Pdz01AvCAottHTPQGzndktFNdbRA75BgOfeT1hH+AMnJFv8lynkPi42rfeEhpx1saTEI3YNMWxfqu0sFD1G8pw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz",
+      "integrity": "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^4.0.0"
+        "is-plain-obj": "^2.0.0"
       },
       "dependencies": {
         "is-plain-obj": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prettier": "^2.0.0",
     "semantic-release": "^20.0.0",
     "semantic-release-plugin-update-version-in-files": "^1.0.0",
-    "sort-keys": "^5.0.0",
+    "sort-keys": "^4.2.0",
     "string-to-jsdoc-comment": "^1.0.0",
     "typedoc": "^0.23.0",
     "typescript": "^4.0.2"


### PR DESCRIPTION
The `sort-keys` dependency switched to ESM and is thus incompatible

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #496

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The automated updates workflows was failing

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The automated update workflow should now run properly


### Other information
<!-- Any other information that is important to this PR  -->

*

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

