### PR TITLE
fix(types): make all parameters in types required for `ExtractRequestBody<T>`

### DIFF
--- a/scripts/update-endpoints/templates/endpoints.ts.template
+++ b/scripts/update-endpoints/templates/endpoints.ts.template
@@ -35,7 +35,7 @@ type ExtractRequestBody<T> = "requestBody" extends keyof T
         }[keyof T["requestBody"]];
       }
   : {};
-type ToOctokitParameters<T> = ExtractParameters<T> & ExtractRequestBody<T>;
+type ToOctokitParameters<T> = ExtractParameters<T> & ExtractRequestBody<Required<T>>;
 
 type RequiredPreview<T> = T extends string
   ? {


### PR DESCRIPTION
…

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #528

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The `ExtractRequestBody<T>` type would potentially return `never` since the `requestBody` was potentially `undefined`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Mark all fields on the path's type as required for the usages of `ExtractRequestBody<T>`
* The returned types have the proper data


### Other information
<!-- Any other information that is important to this PR  -->

* This is a change introduced by `openapi-typescript` v6

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`

----

