### PR TITLE
feat: v11

### DIFF
--- a/src/RequestRequestOptions.ts
+++ b/src/RequestRequestOptions.ts
@@ -6,12 +6,6 @@ import type { Signal } from "./Signal";
  */
 export type RequestRequestOptions = {
   /**
-   * Node only. Useful for custom proxy, certificate, or dns lookup.
-   *
-   * @see https://nodejs.org/api/http.html#http_class_http_agent
-   */
-  agent?: unknown;
-  /**
    * Custom replacement for built-in fetch method. Useful for testing or request hooks.
    */
   fetch?: Fetch;
@@ -19,10 +13,6 @@ export type RequestRequestOptions = {
    * Use an `AbortController` instance to cancel a request. In node you can only cancel streamed requests.
    */
   signal?: Signal;
-  /**
-   * Node only. Request/response timeout in ms, it resets on redirect. 0 to disable (OS limit applies). `options.request.signal` is recommended instead.
-   */
-  timeout?: number;
 
   [option: string]: any;
 };


### PR DESCRIPTION
Removes the agent & timeout options because we are no longer incorporating options for node-fetch. 