### PR TITLE
feat: new `parseSuccessResonseBody` option for requests

### DIFF
--- a/src/RequestRequestOptions.ts
+++ b/src/RequestRequestOptions.ts
@@ -13,6 +13,10 @@ export type RequestRequestOptions = {
    * Use an `AbortController` instance to cancel a request. In node you can only cancel streamed requests.
    */
   signal?: Signal;
+  /**
+   * If set to `false`, the response body will not be parsed and will be returned as a stream.
+   */
+  parseSuccessResponseBody?: boolean;
 
   [option: string]: any;
 };


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Prerequisite to https://github.com/octokit/request.js/pull/602

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The request response data would always be parsed

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Introduces a new option to allow the request response body to not be parsed


### Other information
<!-- Any other information that is important to this PR  -->

*

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Feature/model/API additions: `Type: Feature`

----

