### PR TITLE
fix: bump the version of @octokit/openapi-types to v19.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^19.0.0"
+        "@octokit/openapi-types": "^19.0.1"
       },
       "devDependencies": {
         "@octokit/tsconfig": "^2.0.0",
@@ -248,9 +248,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.0.0.tgz",
-      "integrity": "sha512-PclQ6JGMTE9iUStpzMkwLCISFn/wDeRjkZFIKALpvJQNBGwDoYYi2fFvuHwssoQ1rXI5mfh6jgTgWuddeUzfWw=="
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-19.0.1.tgz",
+      "integrity": "sha512-zC+73r2HIoRb9rWW5S3Y759hrpadlD5pNnya/QfZv0JZE7mvMu+FUa7nxHqTadi2hZc4BPZjJ8veDTuJnh8+8g=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "description": "Shared TypeScript definitions for Octokit projects",
   "dependencies": {
-    "@octokit/openapi-types": "^19.0.0"
+    "@octokit/openapi-types": "^19.0.1"
   },
   "scripts": {
     "build": "node scripts/build.mjs && tsc -p tsconfig.json",


### PR DESCRIPTION
This should unblock updates in https://github.com/octokit/plugin-rest-endpoint-methods.js/pull/687 and https://github.com/octokit/plugin-paginate-rest.js/pull/569.