### PR TITLE
feat(types): make `OctokitResponse` an interface

### DIFF
--- a/src/OctokitResponse.ts
+++ b/src/OctokitResponse.ts
@@ -1,7 +1,7 @@
 import type { ResponseHeaders } from "./ResponseHeaders";
 import type { Url } from "./Url";
 
-export type OctokitResponse<T, S extends number = number> = {
+export interface OctokitResponse<T, S extends number = number> {
   headers: ResponseHeaders;
   /**
    * http response code

--- a/src/OctokitResponse.ts
+++ b/src/OctokitResponse.ts
@@ -15,4 +15,4 @@ export interface OctokitResponse<T, S extends number = number> {
    * Response data as documented in the REST API reference documentation at https://docs.github.com/rest/reference
    */
   data: T;
-};
+}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

Required for https://github.com/octokit/plugin-throttling.js/pull/642
----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Plugins could not define additional properties on the response object

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Allows plugins to extend the response object types by using declaration merging, required in `@octokit/plugin-throttling` due to https://github.com/octokit/plugin-throttling.js/pull/539

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

