### PR TITLE
feat: backport improvements from `@octokit-next`

### DIFF
--- a/scripts/update-endpoints/templates/endpoints.ts.template
+++ b/scripts/update-endpoints/templates/endpoints.ts.template
@@ -4,6 +4,12 @@ import type { OctokitResponse } from "../OctokitResponse";
 import type { RequestHeaders } from "../RequestHeaders";
 import type { RequestRequestOptions } from "../RequestRequestOptions";
 
+/**
+ * @license (MIT OR CC0-1.0)
+ * @source https://github.com/sindresorhus/type-fest/blob/570e27f8fdaee37ef5d5e0fbf241e0212ff8fc1a/source/simplify.d.ts
+ */
+export type Simplify<T> = {[KeyType in keyof T]: T[KeyType]} & {};
+
 // https://stackoverflow.com/a/50375286/206879
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
   k: infer I
@@ -40,30 +46,34 @@ type ExtractRequestBody<T> = "requestBody" extends keyof T
 type ToOctokitParameters<T> = ExtractParameters<T> & ExtractRequestBody<Required<T>>;
 
 type Operation<Url extends keyof paths, Method extends keyof paths[Url]> = {
-  parameters: ToOctokitParameters<paths[Url][Method]>;
-  request: {
-    method: Method extends keyof MethodsMap ? MethodsMap[Method] : never;
-    url: Url;
-    headers: RequestHeaders;
-    request: RequestRequestOptions;
-  };
+  parameters: Simplify<ToOctokitParameters<paths[Url][Method]>>;
+  request: Method extends ReadOnlyMethods
+    ? {
+        method: Method extends string ? Uppercase<Method> : never;
+        url: Url;
+        headers: RequestHeaders;
+        request: RequestRequestOptions;
+      }
+    : {
+        method: Method extends string ? Uppercase<Method> : never;
+        url: Url;
+        headers: RequestHeaders;
+        request: RequestRequestOptions;
+        data: ExtractRequestBody<paths[Url][Method]>;
+      };
   response: ExtractOctokitResponse<paths[Url][Method]>;
 };
 
-type MethodsMap = {
-  delete: "DELETE";
-  get: "GET";
-  patch: "PATCH";
-  post: "POST";
-  put: "PUT";
-};
-type SuccessStatuses = 200 | 201 | 202 | 204;
+type ReadOnlyMethods = "get" | "head";
+type SuccessStatuses = 200 | 201 | 202 | 204 | 205;
 type RedirectStatuses = 301 | 302;
-type EmptyResponseStatuses = 201 | 204;
+type EmptyResponseStatuses = 201 | 204 | 205;
 type KnownJsonResponseTypes =
   | "application/json"
+  | "application/octocat-stream" // GET /octocat
   | "application/scim+json"
-  | "text/html";
+  | "text/html"
+  | "text/plain"; // GET /zen
 
 type SuccessResponseDataType<Responses> = {
   [K in SuccessStatuses & keyof Responses]: GetContentKeyIfPresent<

--- a/src/generated/Endpoints.ts
+++ b/src/generated/Endpoints.ts
@@ -4,6 +4,12 @@ import type { OctokitResponse } from "../OctokitResponse";
 import type { RequestHeaders } from "../RequestHeaders";
 import type { RequestRequestOptions } from "../RequestRequestOptions";
 
+/**
+ * @license (MIT OR CC0-1.0)
+ * @source https://github.com/sindresorhus/type-fest/blob/570e27f8fdaee37ef5d5e0fbf241e0212ff8fc1a/source/simplify.d.ts
+ */
+export type Simplify<T> = { [KeyType in keyof T]: T[KeyType] } & {};
+
 // https://stackoverflow.com/a/50375286/206879
 type UnionToIntersection<U> = (U extends any ? (k: U) => void : never) extends (
   k: infer I,
@@ -41,30 +47,34 @@ type ToOctokitParameters<T> = ExtractParameters<T> &
   ExtractRequestBody<Required<T>>;
 
 type Operation<Url extends keyof paths, Method extends keyof paths[Url]> = {
-  parameters: ToOctokitParameters<paths[Url][Method]>;
-  request: {
-    method: Method extends keyof MethodsMap ? MethodsMap[Method] : never;
-    url: Url;
-    headers: RequestHeaders;
-    request: RequestRequestOptions;
-  };
+  parameters: Simplify<ToOctokitParameters<paths[Url][Method]>>;
+  request: Method extends ReadOnlyMethods
+    ? {
+        method: Method extends string ? Uppercase<Method> : never;
+        url: Url;
+        headers: RequestHeaders;
+        request: RequestRequestOptions;
+      }
+    : {
+        method: Method extends string ? Uppercase<Method> : never;
+        url: Url;
+        headers: RequestHeaders;
+        request: RequestRequestOptions;
+        data: ExtractRequestBody<paths[Url][Method]>;
+      };
   response: ExtractOctokitResponse<paths[Url][Method]>;
 };
 
-type MethodsMap = {
-  delete: "DELETE";
-  get: "GET";
-  patch: "PATCH";
-  post: "POST";
-  put: "PUT";
-};
-type SuccessStatuses = 200 | 201 | 202 | 204;
+type ReadOnlyMethods = "get" | "head";
+type SuccessStatuses = 200 | 201 | 202 | 204 | 205;
 type RedirectStatuses = 301 | 302;
-type EmptyResponseStatuses = 201 | 204;
+type EmptyResponseStatuses = 201 | 204 | 205;
 type KnownJsonResponseTypes =
   | "application/json"
+  | "application/octocat-stream" // GET /octocat
   | "application/scim+json"
-  | "text/html";
+  | "text/html"
+  | "text/plain"; // GET /zen
 
 type SuccessResponseDataType<Responses> = {
   [K in SuccessStatuses & keyof Responses]: GetContentKeyIfPresent<


### PR DESCRIPTION
Backports some improvements from `@octokit-next`:

- Simplify (flatten) the parameters
- Add type support for 205 HTTP status code
- Add types for the `data` parameter

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

