### PR TITLE
feat: add return types for `request.parseSuccessResponseBody`

### DIFF
--- a/src/RequestInterface.ts
+++ b/src/RequestInterface.ts
@@ -3,8 +3,13 @@ import type { OctokitResponse } from "./OctokitResponse";
 import type { RequestParameters } from "./RequestParameters";
 import type { Route } from "./Route";
 
-import type { Endpoints } from "./generated/Endpoints";
+import type { Endpoints, Simplify } from "./generated/Endpoints";
 
+/**
+ * Parameters that can be passed into `request(route, parameters)` or `endpoint(route, parameters)` methods.
+ * This type represents the options when `request.parseSuccessResponseBody` is set to `false`.
+ */
+type StreamBodyOption = Simplify<RequestParameters & { request: { parseSuccessResponseBody: false }}>
 export interface RequestInterface<D extends object = object> {
   /**
    * Sends a request based on endpoint options
@@ -16,7 +21,34 @@ export interface RequestInterface<D extends object = object> {
         ? { url?: string }
         : { url: string }),
   ): Promise<OctokitResponse<T>>;
+  
 
+  /**
+   * Sends a request based on endpoint options
+   *
+   * @param {object} endpoint Must set `method` and `url`. Plus URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
+   */
+  <T = any, O extends StreamBodyOption = StreamBodyOption>(
+    options: O & { method?: string } & ("url" extends keyof D
+        ? { url?: string }
+        : { url: string }),
+  ): Promise<OctokitResponse<ReadableStream<T>>>;
+
+  /**
+   * Sends a request based on endpoint options
+   *
+   * @param {string} route Request method + URL. Example: `'GET /orgs/{org}'`
+   * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
+   */
+  <R extends Route, O extends StreamBodyOption>(
+    route: keyof Endpoints | R,
+    options?: R extends keyof Endpoints
+      ? Endpoints[R]["parameters"] & O
+      : StreamBodyOption,
+  ): R extends keyof Endpoints
+    ? Promise<Endpoints[R]["response"]>
+    : Promise<OctokitResponse<ReadableStream<any>>>;
+    
   /**
    * Sends a request based on endpoint options
    *


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #606 

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The response types would always return the data as an object whether or not the `request.parseSuccessResponseBody` was set to `false`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The response types take into account the `request.parseSuccessResponseBody`, and set it to be `ReadableStream`

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

