### PR TITLE
Fix release.yml by only running for octokit owner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   release:
+    if: github.repository_owner == 'octokit'
     name: release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #613

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* release.yml fails on forks

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* release.yml won't fail on forks

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

