### PR TITLE
fix: restore CJS compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "access": "public",
     "provenance": true
   },
-  "type": "module",
   "description": "Shared TypeScript definitions for Octokit projects",
   "dependencies": {
     "@octokit/openapi-types": "^22.2.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "outDir": "pkg/dist-types",
     "emitDeclarationOnly": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "verbatimModuleSyntax": false
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Compatibility was accidentally removed from this package in https://github.com/octokit/types.ts/commit/a3a96043f3efc81a9ea3601bc8261e2877de94dd

Typescript falsely reports that this package isn't compatible with CJS when it is. This package contains no runtime code and only types.

This is due to adding `"type": "module"` to the `package.json` in order to fix some type issues introduced by upgrading `@octokit/tsconfig`

Fixes octokit/types.ts#650 