### PR TITLE
fix: remove `@types/node` from generated types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
       },
       "devDependencies": {
         "@octokit/tsconfig": "^4.0.0",
-        "@types/node": ">= 8",
         "github-openapi-graphql-query": "^4.0.0",
         "handlebars": "^4.7.6",
         "npm-run-all2": "^7.0.0",
@@ -3372,16 +3371,16 @@
       }
     },
     "node_modules/npm-run-all2": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-7.0.0.tgz",
-      "integrity": "sha512-hXQT0BFU0G37H516ZJgISho4FslbdqMj7U8A7xoj81mhYSyxnwfF6dsraWAA1xL7ak/8yUVvAN4Lx4PpTc5Ohg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-7.0.1.tgz",
+      "integrity": "sha512-Adbv+bJQ8UTAM03rRODqrO5cx0YU5KCG2CvHtSURiadvdTjjgGJXdbc1oQ9CXBh9dnGfHSoSB1Web/0Dzp6kOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
         "cross-spawn": "^7.0.3",
         "memorystream": "^0.3.1",
-        "minimatch": "^10.0.1",
+        "minimatch": "^9.0.0",
         "pidtree": "^0.6.0",
         "read-package-json-fast": "^4.0.0",
         "shell-quote": "^1.7.3",
@@ -3394,7 +3393,7 @@
         "run-s": "bin/run-s/index.js"
       },
       "engines": {
-        "node": "^20.5.0 || >=22.0.0",
+        "node": "^18.17.0 || >=20.5.0",
         "npm": ">= 9"
       }
     },
@@ -3403,7 +3402,6 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
       "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -3419,16 +3417,15 @@
       }
     },
     "node_modules/npm-run-all2/node_modules/minimatch": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "license": "MIT",
   "devDependencies": {
     "@octokit/tsconfig": "^4.0.0",
-    "@types/node": ">= 8",
     "github-openapi-graphql-query": "^4.0.0",
     "handlebars": "^4.7.6",
     "npm-run-all2": "^7.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "pkg/dist-types",
     "emitDeclarationOnly": true,
     "sourceMap": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "lib": ["es2022", "dom"]
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
See https://github.com/octokit/octokit.js/issues/2762#issuecomment-2486997620

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Types would include a reference to `@types/node` even though there is nothing using Node specific APIs in the types

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Remove dependency on `@types/node` to make sure types are platform agnostic

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

