### PR TITLE
fix: implement some performance improvements

### DIFF
--- a/scripts/update-endpoints/templates/endpoints.ts.template
+++ b/scripts/update-endpoints/templates/endpoints.ts.template
@@ -117,3 +117,5 @@ export interface Endpoints {
   >,
   {{/each}}
 }
+
+export type EndpointKeys = keyof Endpoints;

--- a/src/EndpointDefaults.ts
+++ b/src/EndpointDefaults.ts
@@ -7,7 +7,7 @@ import type { Url } from "./Url.js";
  * The `.endpoint()` method is guaranteed to set all keys defined by RequestParameters
  * as well as the method property.
  */
-export type EndpointDefaults = RequestParameters & {
+export interface EndpointDefaults extends RequestParameters {
   baseUrl: Url;
   method: RequestMethod;
   url?: Url;
@@ -19,4 +19,4 @@ export type EndpointDefaults = RequestParameters & {
     format: string;
     previews?: string[];
   };
-};
+}

--- a/src/EndpointInterface.ts
+++ b/src/EndpointInterface.ts
@@ -3,7 +3,7 @@ import type { RequestOptions } from "./RequestOptions.js";
 import type { RequestParameters } from "./RequestParameters.js";
 import type { Route } from "./Route.js";
 
-import type { Endpoints } from "./generated/Endpoints.js";
+import type { EndpointKeys, Endpoints } from "./generated/Endpoints.js";
 
 export interface EndpointInterface<D extends object = object> {
   /**
@@ -25,13 +25,13 @@ export interface EndpointInterface<D extends object = object> {
    */
   <
     R extends Route,
-    P extends RequestParameters = R extends keyof Endpoints
+    P extends RequestParameters = R extends EndpointKeys
       ? Endpoints[R]["parameters"] & RequestParameters
       : RequestParameters,
   >(
-    route: keyof Endpoints | R,
+    route: EndpointKeys | R,
     parameters?: P,
-  ): (R extends keyof Endpoints ? Endpoints[R]["request"] : RequestOptions) &
+  ): (R extends EndpointKeys ? Endpoints[R]["request"] : RequestOptions) &
     Pick<P, keyof RequestOptions>;
 
   /**
@@ -57,14 +57,14 @@ export interface EndpointInterface<D extends object = object> {
      */
     <
       R extends Route,
-      P extends RequestParameters = R extends keyof Endpoints
+      P extends RequestParameters = R extends EndpointKeys
         ? Endpoints[R]["parameters"] & RequestParameters
         : RequestParameters,
     >(
-      route: keyof Endpoints | R,
+      route: EndpointKeys | R,
       parameters?: P,
     ): D &
-      (R extends keyof Endpoints
+      (R extends EndpointKeys
         ? Endpoints[R]["request"] & Endpoints[R]["parameters"]
         : EndpointDefaults) &
       P;

--- a/src/EndpointOptions.ts
+++ b/src/EndpointOptions.ts
@@ -2,7 +2,7 @@ import type { RequestMethod } from "./RequestMethod.js";
 import type { Url } from "./Url.js";
 import type { RequestParameters } from "./RequestParameters.js";
 
-export type EndpointOptions = RequestParameters & {
+export interface EndpointOptions extends RequestParameters {
   method: RequestMethod;
   url: Url;
-};
+}

--- a/src/RequestInterface.ts
+++ b/src/RequestInterface.ts
@@ -3,7 +3,7 @@ import type { OctokitResponse } from "./OctokitResponse.js";
 import type { RequestParameters } from "./RequestParameters.js";
 import type { Route } from "./Route.js";
 
-import type { Endpoints } from "./generated/Endpoints.js";
+import type { EndpointKeys, Endpoints } from "./generated/Endpoints.js";
 
 export interface RequestInterface<D extends object = object> {
   /**
@@ -24,11 +24,11 @@ export interface RequestInterface<D extends object = object> {
    * @param {object} [parameters] URL, query or body parameters, as well as `headers`, `mediaType.{format|previews}`, `request`, or `baseUrl`.
    */
   <R extends Route>(
-    route: keyof Endpoints | R,
-    options?: R extends keyof Endpoints
+    route: EndpointKeys | R,
+    options?: R extends EndpointKeys
       ? Endpoints[R]["parameters"] & RequestParameters
       : RequestParameters,
-  ): R extends keyof Endpoints
+  ): R extends EndpointKeys
     ? Promise<Endpoints[R]["response"]>
     : Promise<OctokitResponse<any>>;
 

--- a/src/generated/Endpoints.ts
+++ b/src/generated/Endpoints.ts
@@ -6708,3 +6708,5 @@ export interface Endpoints {
     "put"
   >;
 }
+
+export type EndpointKeys = keyof Endpoints;


### PR DESCRIPTION
* Pre-compute the keys of the `Endpoint` type in order to not have to compute them multiple times
* Use interface extends instead of intersections

See https://github.com/microsoft/TypeScript/wiki/Performance
Part of #666

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->


----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Utilized `keyof Endpoint` directly in the code many times across different files
* Used intersections for extending types

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Pre-compute the keys of the `Endpoint` type that can be shared across many files
* Utilize interfaces and `extends` for better performance

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

